### PR TITLE
Address pre-commit action failing on PRs for go modules

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -43,6 +43,13 @@ jobs:
           go mod tidy
           pushd magefiles; go mod tidy; popd
 
+      - name: Commit go.mod and go.sum changes to keep pre-commit happy
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          git add go.mod go.sum
+          git diff --quiet && git diff --staged --quiet || git commit -m "Update go.mod and go.sum"
+
       - name: Install pre-commit dependencies
         run: mage installDeps
 


### PR DESCRIPTION
# Proposed Changes

- Add new block to the pre-commit action to address failures for PRs created by renovate for go modules.

## Related Issue(s)

- https://github.com/facebookincubator/TTPForge/issues/38

## Testing

No testing was done.

## Documentation

N/A

## Screenshots/GIFs (optional)

N/A

## Checklist

- [ x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [ x] Ran `mage runtests` locally and fixed any issues that arose.
- [ x] Curated your commits so they are legible and easy to read and understand.
- [ x] 🚀
