### PR TITLE
Add proxy functions and tests

### DIFF
--- a/pkg/network/proxy.go
+++ b/pkg/network/proxy.go
@@ -1,0 +1,135 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package network
+
+import "os"
+
+// EnableHTTPSProxy sets the environment variables "https_proxy" and "http_proxy" to the provided proxy string.
+// This enables an HTTPS proxy for network operations in the current process.
+//
+// Parameters:
+//
+// proxy: A string representing the URL of the proxy server to be used for HTTPS connections.
+//
+// Returns:
+//
+// # None
+//
+// Example:
+//
+// proxy := "http://proxy.example.com:8080"
+// EnableHTTPSProxy(proxy)
+func EnableHTTPSProxy(proxy string) {
+	os.Setenv("https_proxy", proxy)
+	os.Setenv("http_proxy", proxy)
+}
+
+// DisableHTTPSProxy unsets the "https_proxy" and "http_proxy" environment variables.
+// This disables the HTTPS proxy for network operations in the current process.
+//
+// Parameters:
+//
+// proxy: A string representing the URL of the proxy server to be used for HTTPS connections.
+//
+// Returns:
+//
+// # None
+//
+// Example:
+//
+// proxy := "http://proxy.example.com:8080"
+// EnableHTTPSProxy(proxy)
+func DisableHTTPSProxy() {
+	os.Unsetenv("https_proxy")
+}
+
+// EnableNoProxy sets the "no_proxy" environment variable to the provided domains string.
+// This excludes the specified domains from being proxied for network operations in the current process.
+//
+// Parameters:
+//
+// domains: A string representing a comma-separated list of domain names to be excluded from proxying.
+//
+// Returns:
+//
+// # None
+//
+// Example:
+//
+// domains := "example.com,example.org"
+// EnableNoProxy(domains)
+func EnableNoProxy(domains string) {
+	os.Setenv("no_proxy", domains)
+}
+
+// DisableNoProxy unsets the "no_proxy" environment variable.
+// This clears the list of domains excluded from being proxied for network operations in the current process.
+//
+// Parameters:
+//
+// # None
+//
+// Returns:
+//
+// # None
+//
+// Example:
+//
+// DisableNoProxy()
+func DisableNoProxy() {
+	os.Unsetenv("no_proxy")
+}
+
+// EnableHTTPProxy sets the "http_proxy" environment variable to the provided proxy string.
+// This enables an HTTP proxy for network operations in the current process.
+//
+// Parameters:
+//
+// proxy: A string representing the URL of the proxy server to be used for HTTP connections.
+//
+// Returns:
+//
+// # None
+//
+// Example:
+//
+// proxy := "http://proxy.example.com:8080"
+// EnableHTTPProxy(proxy)
+func EnableHTTPProxy(proxy string) {
+	os.Setenv("http_proxy", proxy)
+}
+
+// DisableHTTPProxy unsets the "http_proxy" environment variable.
+// This disables the HTTP proxy for network operations in the current process.
+//
+// Parameters:
+//
+// # None
+//
+// Returns:
+//
+// # None
+//
+// Example:
+//
+// DisableHTTPProxy()
+func DisableHTTPProxy() {
+	os.Unsetenv("http_proxy")
+}

--- a/pkg/network/proxy_test.go
+++ b/pkg/network/proxy_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package network_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/facebookincubator/ttpforge/pkg/network"
+)
+
+func TestEnableHTTPSProxy(t *testing.T) {
+	tests := []struct {
+		name  string
+		proxy string
+	}{
+		{
+			name:  "Enable proxy",
+			proxy: "http://proxy.example.com:8080",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			network.EnableHTTPSProxy(tc.proxy)
+
+			httpsProxy, _ := os.LookupEnv("https_proxy")
+
+			if httpsProxy != tc.proxy {
+				t.Errorf("expected https_proxy to be set to %s, got https_proxy: %s", tc.proxy, httpsProxy)
+			}
+		})
+	}
+}
+
+func TestDisableHTTPSProxy(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "Disable proxy",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			network.DisableHTTPSProxy()
+
+			httpsProxy, httpsExists := os.LookupEnv("https_proxy")
+
+			if httpsExists {
+				t.Errorf("expected https_proxy to be unset, https_proxy: %s", httpsProxy)
+			}
+		})
+	}
+}
+
+func TestEnableNoProxy(t *testing.T) {
+	testCases := []struct {
+		name    string
+		domains string
+	}{
+		{
+			name:    "Single domain",
+			domains: "example.com",
+		},
+		{
+			name:    "Multiple domains",
+			domains: "example.com,example.org",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			network.EnableNoProxy(tc.domains)
+			result := os.Getenv("no_proxy")
+			if result != tc.domains {
+				t.Errorf("Expected no_proxy to be set to '%s', but got '%s'", tc.domains, result)
+			}
+		})
+	}
+}
+
+func TestDisableNoProxy(t *testing.T) {
+	os.Setenv("no_proxy", "example.com")
+	network.DisableNoProxy()
+	result := os.Getenv("no_proxy")
+	if result != "" {
+		t.Errorf("Expected no_proxy to be unset, but got '%s'", result)
+	}
+}
+
+func TestEnableHTTPProxy(t *testing.T) {
+	proxy := "http://proxy.example.com:8080"
+	network.EnableHTTPProxy(proxy)
+	result := os.Getenv("http_proxy")
+	if result != proxy {
+		t.Errorf("Expected http_proxy to be set to '%s', but got '%s'", proxy, result)
+	}
+}
+
+func TestDisableHTTPProxy(t *testing.T) {
+	os.Setenv("http_proxy", "http://proxy.example.com:8080")
+	network.DisableHTTPProxy()
+	result := os.Getenv("http_proxy")
+	if result != "" {
+		t.Errorf("Expected http_proxy to be unset, but got '%s'", result)
+	}
+}


### PR DESCRIPTION
- Closes #8

# Proposed Changes

This PR adds new functions and tests to a `network` package for managing `NO_PROXY`, `HTTPS_PROXY` and `HTTP_PROXY` environment variables.

The new functions are:

- `EnableNoProxy(domains string)`: Sets the `no_proxy` environment variable to the provided domains string.
- `DisableNoProxy()`: Unsets the `no_proxy` environment variable.
- `EnableHTTPProxy(proxy string)`: Sets the `http_proxy` environment variable to the provided proxy string.
- `DisableHTTPProxy()`: Unsets the `http_proxy` environment variable.

## Related Issue(s)

- https://github.com/facebookincubator/TTPForge/issues/8

## Testing

Unit tests have been added for the new functions:

- `TestEnableNoProxy()`: Tests the `EnableNoProxy()` function to ensure it sets the `no_proxy` environment variable correctly.
- `TestDisableNoProxy()`: Tests the `DisableNoProxy()` function to ensure it unsets the `no_proxy` environment variable correctly.
- `TestEnableHTTPProxy()`: Tests the `EnableHTTPProxy()` function to ensure it sets the `http_proxy` environment variable correctly.
- `TestDisableHTTPProxy()`: Tests the `DisableHTTPProxy()` function to ensure it unsets the `http_proxy` environment variable correctly.

All tests have been run and passed.

## Documentation

N/A

## Screenshots/GIFs (optional)

N/A

## Checklist

- [ x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [ x] Ran `mage runtests` locally and fixed any issues that arose.
- [ x] Curated your commits so they are legible and easy to read and understand.
- [ x] 🚀
