### PR TITLE
Minor bug fixes and enhancements

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -10,6 +10,12 @@ area/go:
   - "pkg/**/*"
   - "cmd/**/*"
   - "main.go"
+  - "magefiles/*"
+  - "go.mod"
+  - "go.sum"
+
+area/mage:
+  - "magefiles/*"
 
 area/docs:
   - "docs/*"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
-          git add go.mod go.sum
+          git add go.mod go.sum magefiles/go.mod magefiles/go.sum
           git diff --quiet && git diff --staged --quiet || git commit -m "Update go.mod and go.sum"
 
       - name: Install pre-commit dependencies

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/acomagu/bufpipe v1.0.4 // indirect
 	github.com/bitfield/script v0.21.4 // indirect
 	github.com/cavaliergopher/grab/v3 v3.0.1 // indirect
-	github.com/cloudflare/circl v1.3.2 // indirect
+	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
-github.com/cloudflare/circl v1.3.2 h1:VWp8dY3yH69fdM7lM6A1+NhhVoDu9vqK0jOgmkQHFWk=
-github.com/cloudflare/circl v1.3.2/go.mod h1:+CauBF6R70Jqcyl8N2hC8pAXYbWkGIezuSbuGLtRhnw=
+github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
+github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -74,8 +74,6 @@ func InstallPreCommitHooks() error {
 
 // RunPreCommit runs all pre-commit hooks locally
 func RunPreCommit() error {
-	mg.Deps(InstallDeps)
-
 	fmt.Println(color.YellowString("Updating pre-commit hooks."))
 	if err := goutils.UpdatePCHooks(); err != nil {
 		return err
@@ -97,8 +95,6 @@ func RunPreCommit() error {
 
 // RunTests runs all of the unit tests
 func RunTests() error {
-	mg.Deps(InstallDeps)
-
 	fmt.Println(color.YellowString("Running unit tests."))
 	if err := sh.RunV(filepath.Join(".hooks", "go-unit-tests.sh"), "all"); err != nil {
 		return fmt.Errorf(color.RedString("failed to run unit tests: %v", err))


### PR DESCRIPTION
# Proposed Changes

- Added missing areas of the codebase to the go/area labeler
- Fixed bug in the pre-commit github action - it was not accounting for magefile dependencies
- Significantly improve the run time for `RunTests()` and `RunPreCommit()` in the magefile by removing the `mg.Deps(InstallDeps)` calls from each.

## Related Issue(s)

N/A

## Testing

Ran locally with act (see `container.md` for specifics)

## Documentation

N/A

## Screenshots/GIFs (optional)

N/A

## Checklist

- [x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Ran `mage runtests` locally and fixed any issues that arose.
- [x] Curated your commits so they are legible and easy to read and understand.
- [x] 🚀
