### PR TITLE
Add cleanup-delay-seconds CLI parameter - useful for TTP iteration

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,6 +64,7 @@ func RunTTPCmd() *cobra.Command {
 		},
 	}
 	runCmd.PersistentFlags().BoolVar(&ttpCfg.NoCleanup, "no-cleanup", false, "Disable cleanup (useful for debugging)")
+	runCmd.PersistentFlags().UintVar(&ttpCfg.CleanupDelaySeconds, "cleanup-delay-seconds", 0, "Wait this long after TTP execution before starting cleanup")
 	runCmd.Flags().StringArrayVarP(&argsList, "arg", "a", []string{}, "variable input mapping for args to be used in place of inputs defined in each ttp file")
 
 	return runCmd

--- a/pkg/blocks/context.go
+++ b/pkg/blocks/context.go
@@ -28,9 +28,10 @@ import (
 
 // TTPExecutionConfig - pass this into RunSteps to control TTP execution
 type TTPExecutionConfig struct {
-	NoCleanup      bool
-	Args           map[string]string
-	TTPSearchPaths []string
+	NoCleanup           bool
+	CleanupDelaySeconds uint
+	Args                map[string]string
+	TTPSearchPaths      []string
 }
 
 // TTPExecutionContext - holds config and context for the currently executing TTP

--- a/pkg/blocks/ttps.go
+++ b/pkg/blocks/ttps.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/facebookincubator/ttpforge/pkg/args"
 	"github.com/facebookincubator/ttpforge/pkg/logging"
@@ -266,6 +267,10 @@ func (t *TTP) RunSteps(execCfg TTPExecutionConfig) (*StepResultsRecord, error) {
 	logging.Logger.Sugar().Info("[*] Completed TTP")
 
 	if !execCtx.Cfg.NoCleanup {
+		if execCtx.Cfg.CleanupDelaySeconds > 0 {
+			logging.Logger.Sugar().Infof("[*] Sleeping for Requested Cleanup Delay of %v Seconds", execCtx.Cfg.CleanupDelaySeconds)
+			time.Sleep(time.Duration(execCtx.Cfg.CleanupDelaySeconds) * time.Second)
+		}
 		if len(cleanup) > 0 {
 			logging.Logger.Sugar().Info("[*] Beginning Cleanup")
 			if err := t.executeCleanupSteps(execCtx, cleanup, *stepResults); err != nil {

--- a/ttps/examples/sub-ttps/my-sub-ttps/ttp1.yaml
+++ b/ttps/examples/sub-ttps/my-sub-ttps/ttp1.yaml
@@ -4,3 +4,5 @@ description: called from subttp example
 steps:
   - name: step_one
     inline: echo hello
+    cleanup:
+      inline: echo cleanup my_sub_ttp_1

--- a/ttps/examples/sub-ttps/my-sub-ttps/ttp2.yaml
+++ b/ttps/examples/sub-ttps/my-sub-ttps/ttp2.yaml
@@ -1,6 +1,10 @@
 ---
 name: my_sub_ttp_2
 description: called from subttp example
+args:
+  - name: arg1
 steps:
   - name: step_one
-    inline: echo "you said {{arg1}}"
+    inline: echo "you said {{args.arg1}}"
+    cleanup:
+      inline: echo cleanup my_sub_ttp_2


### PR DESCRIPTION
This `--cleanup-delay-seconds` parameter for the `ttpforge run` command is useful for protection evaluations 
where a TTP (for example, modifying a sensitive source code file) needs to be left "not-cleaned-up" for a certain amount of time in order for defenders to catch it. 

It complements `--no-cleanup` because sometimes (e.g. when running a container orchestrator TTP) it is handy to 
"fire and forget" a TTP, knowing that it will both be cleaned up eventually but also will be left running long enough to trigger any appropriate detections. 

The need for this is illustrated by folks recently shipping multiple TTPs that feature a `sleep XYZ` bash command at the end to accomplish this same purpose. 

Verified that it works:

```
./ttpforge run --cleanup-delay-seconds 30  ttps/examples/sub-ttps/example.yaml
```