### PR TITLE
Fix #208

### DIFF
--- a/pkg/blocks/context.go
+++ b/pkg/blocks/context.go
@@ -120,6 +120,7 @@ func (c TTPExecutionContext) processStepsVariable(path string) (string, error) {
 
 func (c TTPExecutionContext) processMatch(match string) (string, error) {
 	variableSpecifier := strings.TrimLeft(strings.TrimRight(match, "}"), "{")
+	variableSpecifier = strings.TrimSpace(variableSpecifier)
 	if len(variableSpecifier) == 0 {
 		return "", errors.New("empty string in variable expression")
 	}

--- a/pkg/blocks/context_test.go
+++ b/pkg/blocks/context_test.go
@@ -73,10 +73,12 @@ func TestExpandVariablesStepResults(t *testing.T) {
 			stringsToExpand: []string{
 				"first arg: {{args.arg1}}",
 				"second arg: {{args.arg2}}",
+				"should trim spaces and still work: {{ args.arg2  }}",
 			},
 			expectedResult: []string{
 				"first arg: myarg1",
 				"second arg: myarg2",
+				"should trim spaces and still work: myarg2",
 			},
 			wantError: false,
 		},


### PR DESCRIPTION
Variable expansion now ignores leading and trailing spaces in variable specifier - Closes #208