### PR TITLE
Update instructions to get latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,14 @@ targets and mediums.
 1. Get latest TTPForge release:
 
    ```bash
-   # Download utility functions
    bashutils_url="https://raw.githubusercontent.com/l50/dotfiles/main/bashutils"
 
-   # Define the local path of bashutils.sh
    bashutils_path="/tmp/bashutils"
 
    if [[ ! -f "${bashutils_path}" ]]; then
-      # bashutils.sh doesn't exist locally, so download it
       curl -s "${bashutils_url}" -o "${bashutils_path}"
    fi
 
-   # Source bashutils
-   # shellcheck source=/dev/null
    source "${bashutils_path}"
 
    fetchFromGithub "facebookincubator" "TTPForge" "v1.0.3" ttpforge

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ targets and mediums.
    # shellcheck source=/dev/null
    source "${bashutils_path}"
 
-   fetchFromGithub "facebookincubator" "TTPForge" "v1.0.1" ttpforge $GITHUB_TOKEN
+   fetchFromGithub "facebookincubator" "TTPForge" "v1.0.3" ttpforge
+
+   # Optionally, if you are using the `gh` cli:
+   fetchFromGithub "facebookincubator" "TTPForge" "v1.0.3" ttpforge $GITHUB_TOKEN
    ```
 
    At this point, the latest `ttpforge` release should be in

--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ targets and mediums.
 
 ## Getting started as a user
 
-1. Download and install the [gh cli tool](https://cli.github.com/):
-
-- [macOS](https://github.com/cli/cli#macos)
-- [Linux](https://github.com/cli/cli/blob/trunk/docs/install_linux.md)
-- [Windows](https://github.com/cli/cli#windows)
-
 1. Get latest TTPForge release:
 
    ```bash
@@ -59,6 +53,13 @@ targets and mediums.
 
    At this point, the latest `ttpforge` release should be in
    `~/.local/bin/ttpforge` and subsequently, the `$USER`'s `$PATH`.
+
+   If running in a stripped down system, you can add TTPForge to your `$PATH`
+   with the following command:
+
+   ```bash
+   export PATH=$HOME/.local/bin:$PATH
+   ```
 
 1. Initialize TTPForge configuration
 


### PR DESCRIPTION
# Proposed Changes

Update instructions to remove $GITHUB_TOKEN as a necessary component of getting the latest TTPForge release.

## Related Issue(s)

- Closes #249 

## Testing

Tested on two m1 macOS systems.

## Documentation

Latest release instructions have been updated.

## Screenshots/GIFs (optional)

N/A

## Checklist

- [x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Ran `mage runtests` locally and fixed any issues that arose.
- [x] Curated your commits so they are legible and easy to read and understand.
- [x] 🚀
