### PR TITLE
Reduce User Confusion through Improved Error Handling and Logging

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -20,11 +20,11 @@ The `cmd` package is a part of the TTPForge.
 ### Execute(ExecOptions)
 
 ```go
-Execute(ExecOptions)
+Execute(ExecOptions) error
 ```
 
-Execute adds child commands to the root
-command and sets flags appropriately.
+Execute sets up runtime configuration for the root command
+and adds formatted error handling
 
 ---
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,8 @@ TTPForge is a Purple Team engagement tool to execute Tactics, Techniques, and Pr
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			initConfig()
 		},
+		// we will print our own errors with pretty formatting
+		SilenceErrors: true,
 	}
 )
 
@@ -67,11 +69,17 @@ type ExecOptions struct {
 	AutoInitConfig bool
 }
 
-// Execute adds child commands to the root
-// command and sets flags appropriately.
-func Execute(eo ExecOptions) {
+// Execute sets up runtime configuration for the root command
+// and adds formatted error handling
+func Execute(eo ExecOptions) error {
 	autoInitConfig = eo.AutoInitConfig
-	cobra.CheckErr(rootCmd.Execute())
+	if err := rootCmd.Execute(); err != nil {
+		// we want our own log formatting (for pretty colors)
+		// so we don't use cobra.CheckErr
+		logging.L().Errorf("failed to run command: %v", err)
+		return err
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,7 +76,7 @@ func Execute(eo ExecOptions) error {
 	if err := rootCmd.Execute(); err != nil {
 		// we want our own log formatting (for pretty colors)
 		// so we don't use cobra.CheckErr
-		logging.L().Errorf("failed to run command: %v", err)
+		logging.L().Errorf("failed to run command:\n\t%v", err)
 		return err
 	}
 	return nil
@@ -106,7 +106,7 @@ func initConfig() {
 	}
 
 	// load config file
-	logging.L().Infof("Using config file: %s", Conf.cfgFile)
+	logging.L().Debugf("Using config file: %s", Conf.cfgFile)
 	cfgContents, err := os.ReadFile(Conf.cfgFile)
 	cobra.CheckErr(err)
 	err = yaml.Unmarshal(cfgContents, Conf)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -56,7 +56,7 @@ func RunTTPCmd() *cobra.Command {
 			}
 			ttp, err := blocks.LoadTTP(ttpAbsPath, nil, &c, argsList)
 			if err != nil {
-				return fmt.Errorf("could not load TTP at %v: %v", ttpAbsPath, err)
+				return fmt.Errorf("could not load TTP at %v:\n\t%v", ttpAbsPath, err)
 			}
 
 			if _, err := ttp.RunSteps(c); err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -46,6 +46,9 @@ func RunTTPCmd() *cobra.Command {
 				return fmt.Errorf("failed to resolve TTP reference %v: %v", ttpRef, err)
 			}
 
+			// don't want confusing usage display for errors past this point
+			cmd.SilenceUsage = true
+
 			// load TTP and process argument values
 			// based on the TTPs argument value specifications
 			c := blocks.TTPExecutionConfig{

--- a/main.go
+++ b/main.go
@@ -20,11 +20,19 @@ THE SOFTWARE.
 package main
 
 import (
+	"os"
+
 	"github.com/facebookincubator/ttpforge/cmd"
 )
 
 func main() {
-	cmd.Execute(cmd.ExecOptions{
+	err := cmd.Execute(cmd.ExecOptions{
 		AutoInitConfig: true,
 	})
+	if err != nil {
+		// cobra won't set the right exit code unless
+		// you use cobra.CheckErr, which we don't want to do for
+		// formatting reasons
+		os.Exit(1)
+	}
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -73,6 +73,9 @@ func InitLog(config Config) (err error) {
 		zcfg.Level.SetLevel(zap.DebugLevel)
 	} else {
 		zcfg.Level.SetLevel(zap.InfoLevel)
+		// hide fields that will confuse users during simple user errors
+		zcfg.EncoderConfig.CallerKey = zapcore.OmitKey
+		zcfg.EncoderConfig.TimeKey = zapcore.OmitKey
 	}
 
 	if !config.Stacktrace {


### PR DESCRIPTION
# 1. Remove problematic cobra error printouts

Cleanup the following bad cobra behaviors:

* printing full "Usage" info after all types of errors - this is unhelpful and makes it harder to see what actually went wrong
* Double-printing error messages 

Before: 

<img width="1720" alt="image" src="https://github.com/facebookincubator/TTPForge/assets/106620054/9c04e609-ea51-4e95-bb43-8f821d2d96cb">


After: 

<img width="1058" alt="image" src="https://github.com/facebookincubator/TTPForge/assets/106620054/d8de2757-0415-4277-a2f7-375929a9b916">

# 2. Hide confusing fields behind `verbose` flag

This makes it easier for users to see the information that they care about:

Default output:

<img width="453" alt="image" src="https://github.com/facebookincubator/TTPForge/assets/106620054/456479ad-cda7-40f9-aeaa-f65f3ef776bd">

With verbose: 

<img width="1725" alt="image" src="https://github.com/facebookincubator/TTPForge/assets/106620054/f96cdc3c-f09b-452e-9506-2c1ab40736f0">

