### PR TITLE
Switch to GITHUB_TOKEN for pushing package 

### DIFF
--- a/.devcontainer/bash/Dockerfile
+++ b/.devcontainer/bash/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.21.1-alpine
 
+LABEL org.opencontainers.image.source=https://github.com/facebookincubator/TTPForge
 LABEL org.opencontainers.image.description="Dev Container with dependencies and tools for building and testing the TTPForge project"
 
 ARG GITHUB_CLI_VERSION=2.32.1

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.BOT_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and export to Docker (Test Image)
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4


### PR DESCRIPTION
* This should work once the repository and the package are appropriately linked 
* This keeps the scopes on our bot PAT small, which is desirable for security