### PR TITLE
Add the ability to provide target information for a TTP

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,8 +2,8 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Mage GeneratePackageDocs",
       "type": "go",
+      "name": "Mage GeneratePackageDocs",
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/magefiles/mage_output_file.go",
@@ -24,6 +24,14 @@
         "run",
         "examples/variadic-params/variadicParameterExample.yaml"
       ]
+    },
+    {
+      "type": "go",
+      "request": "launch",
+      "name": "Debug targets example TTP",
+      "mode": "debug",
+      "program": "${workspaceRoot}",
+      "args": ["run", "forgearmory//examples/targets/os-and-arch-target.yaml"]
     },
     {
       "name": "Test Current File",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,6 +29,7 @@ import (
 func buildRunCommand() *cobra.Command {
 	var argsList []string
 	var ttpCfg blocks.TTPExecutionConfig
+	var targetsList []string
 	runCmd := &cobra.Command{
 		Use:   "run [repo_name//path/to/ttp]",
 		Short: "Run the TTP found in the specified YAML file.",
@@ -48,7 +49,7 @@ func buildRunCommand() *cobra.Command {
 			// based on the TTPs argument value specifications
 			ttpCfg.Repo = foundRepo
 
-			ttp, err := blocks.LoadTTP(ttpAbsPath, foundRepo.GetFs(), &ttpCfg, argsList)
+			ttp, err := blocks.LoadTTP(ttpAbsPath, foundRepo.GetFs(), &ttpCfg, argsList, targetsList)
 			if err != nil {
 				return fmt.Errorf("could not load TTP at %v:\n\t%v", ttpAbsPath, err)
 			}
@@ -62,6 +63,7 @@ func buildRunCommand() *cobra.Command {
 	runCmd.PersistentFlags().BoolVar(&ttpCfg.NoCleanup, "no-cleanup", false, "Disable cleanup (useful for debugging and daisy-chaining TTPs)")
 	runCmd.PersistentFlags().UintVar(&ttpCfg.CleanupDelaySeconds, "cleanup-delay-seconds", 0, "Wait this long after TTP execution before starting cleanup")
 	runCmd.Flags().StringArrayVarP(&argsList, "arg", "a", []string{}, "variable input mapping for args to be used in place of inputs defined in each ttp file")
+	runCmd.Flags().StringArrayVarP(&targetsList, "target", "t", []string{}, "variable input mapping to specify targets")
 
 	return runCmd
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -94,6 +94,7 @@ func TestNoCleanupFlag(t *testing.T) {
 		execConfig       blocks.TTPExecutionConfig
 		expectedDirExist bool
 		wantError        bool
+		dirName          string
 	}{
 		{
 			name: "Test No Cleanup Behavior - Directory Creation",
@@ -110,6 +111,7 @@ steps:
 			},
 			expectedDirExist: true,
 			wantError:        false,
+			dirName:          "testDir",
 		},
 		{
 			name: "Test Cleanup Behavior - Directory Deletion",
@@ -126,6 +128,7 @@ steps:
 			},
 			expectedDirExist: false,
 			wantError:        false,
+			dirName:          "testDir2",
 		},
 	}
 
@@ -158,11 +161,7 @@ steps:
 				require.NoError(t, err)
 			}
 
-			// Determine which directory to check based on the test case content
-			dirName := tempDir + "/testDir"
-			if strings.Contains(tc.content, "testDir2") {
-				dirName = tempDir + "/testDir2"
-			}
+			dirName := filepath.Join(tempDir, tc.dirName)
 
 			// Check if the directory exists
 			dirExists, err := afero.DirExists(afs, dirName)

--- a/pkg/blocks/README.md
+++ b/pkg/blocks/README.md
@@ -567,22 +567,25 @@ returns it as a string.
 
 ---
 
-### LoadTTP(string, afero.Fs, *TTPExecutionConfig, []string)
+### LoadTTP(string, afero.Fs, *TTPExecutionConfig, []string, []string)
 
 ```go
-LoadTTP(string, afero.Fs, *TTPExecutionConfig, []string) *TTP, error
+LoadTTP(string, afero.Fs, *TTPExecutionConfig, []string, []string) *TTP, error
 ```
 
 LoadTTP reads a TTP file and creates a TTP instance based on its contents.
+It processes the targets and arguments present in the file, validates them,
+and populates the appropriate fields in the provided TTPExecutionConfig.
 If the file is empty or contains invalid data, it returns an error.
 
-**Parameters:**
-
+Parameters:
 ttpFilePath: the absolute or relative path to the TTP YAML file.
-fsys: an afero.Fs that contains the specified TTP file path
+fsys: an afero.Fs that contains the specified TTP file path.
+execCfg: Configuration containing execution details which will be populated based on parsed targets and arguments.
+argsKvStrs: Key-value strings for argument specifications.
+targetsKvStrs: Key-value strings for target specifications (Currently unused but may be required for future extensions).
 
-**Returns:**
-
+Returns:
 ttp: Pointer to the created TTP instance, or nil if the file is empty or invalid.
 err: An error if the file contains invalid data or cannot be read.
 

--- a/pkg/blocks/context.go
+++ b/pkg/blocks/context.go
@@ -35,6 +35,7 @@ type TTPExecutionConfig struct {
 	NoCleanup           bool
 	CleanupDelaySeconds uint
 	Args                map[string]any
+	Targets             map[string]any
 	Repo                repos.Repo
 }
 

--- a/pkg/blocks/subttp.go
+++ b/pkg/blocks/subttp.go
@@ -162,7 +162,7 @@ func (s *SubTTPStep) loadSubTTP(execCtx TTPExecutionContext) error {
 		return err
 	}
 
-	ttps, err := LoadTTP(subTTPAbsPath, repo.GetFs(), &s.subExecCtx.Cfg, subArgsKv)
+	ttps, err := LoadTTP(subTTPAbsPath, repo.GetFs(), &s.subExecCtx.Cfg, subArgsKv, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/blocks/ttps.go
+++ b/pkg/blocks/ttps.go
@@ -40,6 +40,7 @@ import (
 // Description: A description of the TTP.
 // MitreAttackMapping: A MitreAttack object containing mappings to the MITRE ATT&CK framework.
 // Environment: A map of environment variables to be set for the TTP.
+// Targets: A map of targets to be set for the TTP.
 // Steps: An slice of steps to be executed for the TTP.
 // ArgSpecs: An slice of argument specifications for the TTP.
 // WorkDir: The working directory for the TTP.
@@ -48,6 +49,7 @@ type TTP struct {
 	Description        string            `yaml:"description"`
 	MitreAttackMapping MitreAttack       `yaml:"mitre,omitempty"`
 	Environment        map[string]string `yaml:"env,flow,omitempty"`
+	Targets            Targets           `yaml:"targets,flow,omitempty"`
 	Steps              []Step            `yaml:"steps,omitempty,flow"`
 	ArgSpecs           []args.Spec       `yaml:"args,omitempty,flow"`
 	// Omit WorkDir, but expose for testing.
@@ -65,6 +67,30 @@ type MitreAttack struct {
 	Tactics       []string `yaml:"tactics,omitempty"`
 	Techniques    []string `yaml:"techniques,omitempty"`
 	SubTechniques []string `yaml:"subtechniques,omitempty"`
+}
+
+// Targets represents the targets structure for a TTP.
+//
+// **Attributes:**
+//
+// Name: The name of the target.
+// Description: A description of the target.
+// Targets: A map of targets to be set for the TTP.
+type Targets struct {
+	OS    []string `yaml:"os,omitempty"`
+	Arch  []string `yaml:"arch,omitempty"`
+	Cloud []Cloud  `yaml:"cloud,omitempty"`
+}
+
+// Cloud represents the cloud provider structure for a TTP.
+//
+// **Attributes:**
+//
+// Provider: The name of the cloud provider to be targeted.
+// Region: The name of the cloud region to be targeted.
+type Cloud struct {
+	Provider string `yaml:"provider,omitempty"`
+	Region   string `yaml:"region,omitempty"`
 }
 
 // MarshalYAML is a custom marshalling implementation for the TTP structure.
@@ -136,6 +162,7 @@ func (t *TTP) UnmarshalYAML(node *yaml.Node) error {
 		Name        string            `yaml:"name,omitempty"`
 		Description string            `yaml:"description"`
 		Environment map[string]string `yaml:"env,flow,omitempty"`
+		Targets     Targets           `yaml:"targets,flow,omitempty"`
 		Steps       []yaml.Node       `yaml:"steps,omitempty,flow"`
 		ArgSpecs    []args.Spec       `yaml:"args,omitempty,flow"`
 	}
@@ -148,6 +175,7 @@ func (t *TTP) UnmarshalYAML(node *yaml.Node) error {
 	t.Name = tmpl.Name
 	t.Description = tmpl.Description
 	t.Environment = tmpl.Environment
+	t.Targets = tmpl.Targets
 	t.ArgSpecs = tmpl.ArgSpecs
 
 	// Check for and handle a mitre node

--- a/pkg/blocks/ttps_test.go
+++ b/pkg/blocks/ttps_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/facebookincubator/ttpforge/pkg/blocks"
+	"github.com/facebookincubator/ttpforge/pkg/targets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -114,6 +115,44 @@ steps:
       echo -e "Searching for aws keys on disk using mdfind..."
       mdfind "kMDItemTextContent == '*AKIA*' || kMDItemDisplayName == '*AKIA*' -onlyin ~"
       echo "[+] TTP Done!"
+`,
+			wantError: false,
+		},
+		{
+			name: "OS and Arch",
+			content: `
+---
+name: os-and-arch-target
+description: |
+  Example demonstrating how to create a TTP that works for specific
+  operating systems and architectures.
+
+  This TTP also demonstrates how to create a TTP that can
+  be used for specific cloud providers and regions.
+targets:
+  os:
+    - linux
+    - macos
+  arch:
+    - x86_64
+    - arm64
+  cloud:
+    - provider: "aws"
+      region: "us-west-1"
+    - provider: "gcp"
+      region: "us-west1-a"
+    - provider: "azure"
+      region: "eastus"
+
+steps:
+  - name: friendly-message
+    inline: |
+      set -e
+
+      echo -e "You are running a TTP that works for the following operating systems: {{ .Targets.os }}"
+      echo -e "and architectures: {{ .Targets.arch }}."
+      echo -e "It can be used for the following cloud providers"
+      echo -e "at the specified regions as well: {{ .Targets.cloud }}."
 `,
 			wantError: false,
 		},
@@ -454,10 +493,10 @@ targets:
 			expectedTTP: blocks.TTP{
 				Name:        "cloud-target",
 				Description: "Test cloud targeting",
-				Targets: blocks.Targets{
+				TargetSpec: targets.TargetSpec{
 					OS:   []string{"linux", "windows"},
 					Arch: []string{"x86_64", "arm64"},
-					Cloud: []blocks.Cloud{
+					Cloud: []targets.Cloud{
 						{
 							Provider: "aws",
 							Region:   "us-west-1",
@@ -481,8 +520,8 @@ targets:
 			name: "Valid cloud-only targets",
 			content: `
 ---
-name: cloud-only
-description: Cloud-only target
+name: cloud
+description: Cloud target
 targets:
   cloud:
     - provider: "aws"
@@ -490,10 +529,10 @@ targets:
 `,
 			wantError: false,
 			expectedTTP: blocks.TTP{
-				Name:        "cloud-only",
-				Description: "Cloud-only target",
-				Targets: blocks.Targets{
-					Cloud: []blocks.Cloud{
+				Name:        "cloud",
+				Description: "Cloud target",
+				TargetSpec: targets.TargetSpec{
+					Cloud: []targets.Cloud{
 						{
 							Provider: "aws",
 							Region:   "us-west-1",

--- a/pkg/blocks/ttps_test.go
+++ b/pkg/blocks/ttps_test.go
@@ -478,24 +478,27 @@ targets:
 			},
 		},
 		{
-			name: "Invalid targets with missing cloud",
+			name: "Valid cloud-only targets",
 			content: `
 ---
-name: missing-cloud
-description: Missing cloud target
+name: cloud-only
+description: Cloud-only target
 targets:
-  os:
-    - windows
-  arch:
-    - x86_64
+  cloud:
+    - provider: "aws"
+      region: "us-west-1"
 `,
 			wantError: false,
 			expectedTTP: blocks.TTP{
-				Name:        "missing-cloud",
-				Description: "Missing cloud target",
+				Name:        "cloud-only",
+				Description: "Cloud-only target",
 				Targets: blocks.Targets{
-					OS:   []string{"windows"},
-					Arch: []string{"x86_64"},
+					Cloud: []blocks.Cloud{
+						{
+							Provider: "aws",
+							Region:   "us-west-1",
+						},
+					},
 				},
 				Steps:    nil,
 				ArgSpecs: nil,
@@ -513,7 +516,7 @@ targets:
 			} else {
 				assert.NoError(t, err)
 			}
-			require.Equal(t, tc.expectedTTP, ttp, "Parsed TTP struct does not match expected")
+			require.Equal(t, tc.expectedTTP, ttp, "Parsed Cloud-only TTP struct does not match expected")
 		})
 	}
 }

--- a/pkg/targets/README.md
+++ b/pkg/targets/README.md
@@ -17,6 +17,25 @@ The `targets` package is a part of the TTPForge.
 
 ## Functions
 
+### ParseAndValidateTargets(TargetSpec)
+
+```go
+ParseAndValidateTargets(TargetSpec) map[string]interface{}, error
+```
+
+ParseAndValidateTargets takes a TargetSpec and processes the targets specified in it.
+It then returns a map containing the processed targets. If the TargetSpec does not have any
+valid targets specified, the resulting map will be empty.
+
+Parameters:
+targetSpec: The specifications for valid targets, extracted from the YAML configuration.
+
+Returns:
+processedTargets: A map of target names (like 'os', 'arch', etc.) to their values.
+err: An error if any issues arise during the processing.
+
+---
+
 ## Installation
 
 To use the TTPForge/targets package, you first need to install it.

--- a/pkg/targets/README.md
+++ b/pkg/targets/README.md
@@ -1,0 +1,65 @@
+# TTPForge/targets
+
+The `targets` package is a part of the TTPForge.
+
+---
+
+## Table of contents
+
+- [Functions](#functions)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Tests](#tests)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
+## Functions
+
+## Installation
+
+To use the TTPForge/targets package, you first need to install it.
+Follow the steps below to install via go get.
+
+```bash
+go get github.com/facebookincubator/ttpforge/targets
+```
+
+---
+
+## Usage
+
+After installation, you can import the package in your Go project
+using the following import statement:
+
+```go
+import "github.com/facebookincubator/ttpforge/targets"
+```
+
+---
+
+## Tests
+
+To ensure the package is working correctly, run the following
+command to execute the tests for `TTPForge/targets`:
+
+```bash
+go test -v
+```
+
+---
+
+## Contributing
+
+Pull requests are welcome. For major changes,
+please open an issue first to discuss what
+you would like to change.
+
+---
+
+## License
+
+This project is licensed under the MIT
+License - see the [LICENSE](https://github.com/facebookincubator/TTPForge/blob/main/LICENSE)
+file for details.

--- a/pkg/targets/targetSpec.go
+++ b/pkg/targets/targetSpec.go
@@ -1,0 +1,88 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package targets
+
+// MitreAttack represents mappings to the MITRE ATT&CK framework.
+//
+// **Attributes:**
+//
+// Tactics: A string slice containing the MITRE ATT&CK tactic(s) associated with the TTP.
+// Techniques: A string slice containing the MITRE ATT&CK technique(s) associated with the TTP.
+// SubTechniques: A string slice containing the MITRE ATT&CK sub-technique(s) associated with the TTP.
+type MitreAttack struct {
+	Tactics       []string `yaml:"tactics,omitempty"`
+	Techniques    []string `yaml:"techniques,omitempty"`
+	SubTechniques []string `yaml:"subtechniques,omitempty"`
+}
+
+// TargetSpec represents the specifications for valid targets within a TTP.
+//
+// Attributes:
+// OS: A slice containing the operating systems valid for this TTP.
+// Arch: A slice containing the architectures valid for this TTP.
+// Cloud: A slice of Cloud structs, each representing a cloud provider and region valid for this TTP.
+type TargetSpec struct {
+	OS    []string `yaml:"os,omitempty"`
+	Arch  []string `yaml:"arch,omitempty"`
+	Cloud []Cloud  `yaml:"cloud,omitempty"`
+}
+
+// Cloud represents the cloud provider structure for a TTP.
+//
+// **Attributes:**
+//
+// Provider: The name of the cloud provider to be targeted.
+// Region: The name of the cloud region to be targeted.
+type Cloud struct {
+	Provider string `yaml:"provider,omitempty"`
+	Region   string `yaml:"region,omitempty"`
+}
+
+// ParseAndValidateTargets takes a TargetSpec and processes the targets specified in it.
+// It then returns a map containing the processed targets. If the TargetSpec does not have any
+// valid targets specified, the resulting map will be empty.
+//
+// Parameters:
+// targetSpec: The specifications for valid targets, extracted from the YAML configuration.
+//
+// Returns:
+// processedTargets: A map of target names (like 'os', 'arch', etc.) to their values.
+// err: An error if any issues arise during the processing.
+func ParseAndValidateTargets(targetSpec TargetSpec) (map[string]interface{}, error) {
+	processedTargets := make(map[string]interface{})
+
+	if len(targetSpec.OS) > 0 {
+		processedTargets["os"] = targetSpec.OS
+	}
+
+	if len(targetSpec.Arch) > 0 {
+		processedTargets["arch"] = targetSpec.Arch
+	}
+
+	if len(targetSpec.Cloud) > 0 {
+		var cloudStrs []string
+		for _, cloud := range targetSpec.Cloud {
+			cloudStrs = append(cloudStrs, cloud.Provider+":"+cloud.Region)
+		}
+		processedTargets["cloud"] = cloudStrs
+	}
+
+	return processedTargets, nil
+}

--- a/pkg/targets/targetSpec_test.go
+++ b/pkg/targets/targetSpec_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package targets_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/facebookincubator/ttpforge/pkg/targets"
+)
+
+func TestParseAndValidateTargets(t *testing.T) {
+	tests := []struct {
+		name           string
+		targetSpec     targets.TargetSpec
+		expectedOutput map[string]interface{}
+		expectedError  error
+	}{
+		{
+			name: "OS and Arch only",
+			targetSpec: targets.TargetSpec{
+				OS:   []string{"linux", "windows"},
+				Arch: []string{"x86", "amd64"},
+			},
+			expectedOutput: map[string]interface{}{
+				"os":   []string{"linux", "windows"},
+				"arch": []string{"x86", "amd64"},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Cloud only",
+			targetSpec: targets.TargetSpec{
+				Cloud: []targets.Cloud{
+					{
+						Provider: "aws",
+						Region:   "us-west-1",
+					},
+					{
+						Provider: "gcp",
+						Region:   "us-central1",
+					},
+				},
+			},
+			expectedOutput: map[string]interface{}{
+				"cloud": []string{"aws:us-west-1", "gcp:us-central1"},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Empty TargetSpec",
+			targetSpec: targets.TargetSpec{
+				OS:    nil,
+				Arch:  nil,
+				Cloud: nil,
+			},
+			expectedOutput: map[string]interface{}{},
+			expectedError:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := targets.ParseAndValidateTargets(tc.targetSpec)
+
+			// Check if the error is as expected
+			if err != tc.expectedError {
+				t.Fatalf("expected error %v, but got %v", tc.expectedError, err)
+			}
+
+			// Check if the output matches expected output
+			if !reflect.DeepEqual(output, tc.expectedOutput) {
+				t.Fatalf("expected output %v, but got %v", tc.expectedOutput, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Proposed Changes

This pull request includes the following changes:

1. Added targets specification and related changes to TTPForge:
   - Added new launch configurations in `.vscode/launch.json`.
   - Extended the `run` command in `cmd/run.go` to support target specification.
   - Updated the TTP data structure in `pkg/blocks/ttps.go` to reflect target specs.
   - Modified loading and validation of TTPs in `pkg/blocks/loader.go` to process new target specification.
   - Added a new `targets` package to handle target specifications with an accompanying README.

2. Added `testSpec_test` and created new tests in `ttps_test`.

3. Enhanced the TTP struct with target and cloud attributes and added relevant tests:
   - Extended the TTP structure to support detailed targeting, including OS, architecture, and cloud specifications.
   - Added new `Targets` and `Cloud` structures to capture specific target attributes.
   - Updated unmarshalling functions to accommodate the new fields.
   - Extended test cases to cover the new functionality in TTP.
   - Closes #196.

## Related Issue(s)

Closes #196.

## Testing

I have performed the following testing to validate the changes:

- Ran `mage runprecommit` locally and fixed any issues that arose.
- Ran `mage runtests` locally and fixed any issues that arose.

## Documentation

I have updated the documentation to reflect the changes made in this pull request, including adding details about the new targets specification and related changes, as well as the enhancements to the TTP struct.

## Screenshots/GIFs (optional)

N/A

## Checklist

- [x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Curated your commits so they are legible and easy to read and understand.
- [x] 🚀
