### PR TITLE
Expected step failure

### DIFF
--- a/pkg/blocks/README.md
+++ b/pkg/blocks/README.md
@@ -319,7 +319,7 @@ Cleanup(TTPExecutionContext) *ActResult, error
 
 Cleanup is a method to establish a link with the Cleanup interface.
 Assumes that the type is the cleanup step and is invoked by
-f.CleanupStep.Cleanup.
+u.CleanupStep.Cleanup.
 
 ---
 

--- a/pkg/blocks/basicstep.go
+++ b/pkg/blocks/basicstep.go
@@ -195,10 +195,10 @@ func (b *BasicStep) Validate(execCtx TTPExecutionContext) error {
 
 // Execute runs the BasicStep and returns an error if any occur.
 func (b *BasicStep) Execute(execCtx TTPExecutionContext) (*ExecutionResult, error) {
+	logging.L().Info("========= Executing ==========")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Minute)
 	defer cancel()
-
-	logging.L().Info("========= Executing ==========")
 
 	if b.Inline == "" {
 		return nil, fmt.Errorf("empty inline value in Execute(...)")

--- a/pkg/blocks/editstep.go
+++ b/pkg/blocks/editstep.go
@@ -124,8 +124,11 @@ func (s *EditStep) Validate(execCtx TTPExecutionContext) error {
 
 // Execute runs the EditStep and returns an error if any occur.
 func (s *EditStep) Execute(execCtx TTPExecutionContext) (*ExecutionResult, error) {
+	logging.L().Info("========= Executing ==========")
+
 	fileSystem := s.FileSystem
 	targetPath := s.FileToEdit
+
 	if fileSystem == nil {
 		fileSystem = afero.NewOsFs()
 		var err error
@@ -189,6 +192,8 @@ func (s *EditStep) Execute(execCtx TTPExecutionContext) (*ExecutionResult, error
 		}
 		return nil, err
 	}
+
+	logging.L().Info("========= Result ==========")
 
 	return &ExecutionResult{}, nil
 }

--- a/pkg/blocks/fetchuri_test.go
+++ b/pkg/blocks/fetchuri_test.go
@@ -200,7 +200,6 @@ steps:
 }
 
 func TestFetchURIStepOutput(t *testing.T) {
-
 	// prepare step
 	content := `
 name: test_fetch_file
@@ -239,11 +238,126 @@ overwrite: true
 
 	f, err := os.Stat(s.Location)
 	require.NoError(t, err)
-	assert.Greaterf(t, f.Size(), int64(0), "file exists but contains no data")
+	assert.Greaterf(t, f.Size(), int64(0), "file to download exists but contains no data")
 
 	dat, err := os.ReadFile(s.Location)
 	require.NoError(t, err)
 
 	assert.Equal(t, string(dat), "Hello, client\n")
+}
 
+func TestFetchURIStepUnmarshalIgnoreErrors(t *testing.T) {
+	data := `
+name: fetchStep
+fetch_uri: http://example.com
+location: ./downloaded_file
+ignore_errors: true
+`
+	step := &blocks.FetchURIStep{}
+	err := yaml.Unmarshal([]byte(data), step)
+	assert.NoError(t, err)
+	assert.True(t, step.IgnoreErrors)
+}
+
+func TestFetchURIExecuteWithIgnoreErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	tempFile, err := os.CreateTemp("", "temporary_location")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	step := &blocks.FetchURIStep{
+		Act: &blocks.Act{
+			Type: blocks.StepBasic,
+			Name: "fetchErrorStep",
+		},
+		FetchURI:     ts.URL,
+		Location:     tempFile.Name(),
+		IgnoreErrors: true,
+	}
+
+	ctx := blocks.TTPExecutionContext{}
+
+	result, err := step.Execute(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestFetchURIExecuteWithoutIgnoreErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	tempFile, err := os.CreateTemp("", "temporary_location")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	step := &blocks.FetchURIStep{
+		Act: &blocks.Act{
+			Type: blocks.StepBasic,
+			Name: "fetchErrorStep",
+		},
+		FetchURI:     ts.URL,
+		Location:     tempFile.Name(),
+		IgnoreErrors: false,
+	}
+
+	ctx := blocks.TTPExecutionContext{}
+
+	_, err = step.Execute(ctx)
+	assert.Error(t, err)
+}
+
+func TestValidFetchURIExecuteWithIgnoreErrors(t *testing.T) {
+	// Generate a temporary path
+	tempFile, err := os.CreateTemp("", "valid_location")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name()) // Cleanup after the test
+
+	// Check if the file exists and if so, delete it.
+	if _, err := os.Stat(tempFile.Name()); err == nil {
+		fmt.Printf("File %s exists before test. Deleting...\n", tempFile.Name())
+		os.Remove(tempFile.Name())
+	}
+
+	content := `
+name: test_fetch_file_ignore_errors
+fetch_uri: OVERWRITTEN
+location: ` + tempFile.Name() + `
+ignore_errors: true
+`
+
+	var s blocks.FetchURIStep
+	execCtx := blocks.TTPExecutionContext{
+		Cfg: blocks.TTPExecutionConfig{
+			Args: map[string]any{},
+		},
+	}
+	err = yaml.Unmarshal([]byte(content), &s)
+	require.NoError(t, err)
+
+	// Set up a temporary HTTP test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, fetch client")
+	}))
+	defer ts.Close()
+
+	s.FetchURI = ts.URL
+	err = s.Validate(execCtx)
+	require.NoError(t, err)
+
+	_, err = s.Execute(execCtx)
+	require.NoError(t, err)
+
+	// Read the file content after execution
+	resultContent, err := os.ReadFile(s.Location)
+	require.NoError(t, err)
+
+	// Check the content. Here we expect "Hello, fetch client\n" because that's what the HTTP server returns.
+	expectedContent := "Hello, fetch client\n"
+	assert.Equal(t, expectedContent, string(resultContent))
 }

--- a/pkg/blocks/subttp.go
+++ b/pkg/blocks/subttp.go
@@ -151,7 +151,7 @@ func (s *SubTTPStep) Execute(execCtx TTPExecutionContext) (*ExecutionResult, err
 		logging.L().Infof("[+] Finished running step: %s", stepCopy.StepName())
 	}
 
-	logging.L().Info("Finished execution of sub ttp file")
+	logging.L().Info("========= Result ==========")
 
 	return &ExecutionResult{
 		ActResult: *aggregateResults(results),


### PR DESCRIPTION
# Proposed Changes

This PR introduces improvements and enhanced error handling to various steps within the tool. Specifically, the functionality to handle `ignore_errors` has been added to several step types.

## Related Issue(s)

- Closes #186

## Testing

The following steps have been tested for the new functionality with `ignore_errors`:

- **BasicStep**: Initial attempt to get BasicStep working with `ignore_errors`.
- **FileStep**: Enhanced the FileStep to work with `ignore_errors`.
- **EditStep**: Successfully made the EditStep compatible with `ignore_errors`.
- **SubTTPStep**: Ensured that the SubTTPStep can handle `ignore_errors`.
- **FetchURI step**: Updated the FetchURI step to handle `ignore_errors`, ensuring consistent output.
  
All the above changes were accompanied by the respective tests to validate the functionality.

## Documentation

- There might be a need to update the documentation, outlining the new `ignore_errors` handling for the respective steps.

## Screenshots/GIFs (optional)

- N/A

## Checklist

- [x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Ran `mage runtests` locally and fixed any issues that arose.
- [x] Curated your commits so they are legible and easy to read and understand.
- [x] 🚀