### PR TITLE
Fix --no-cleanup

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -48,12 +48,6 @@ func buildRunCommand() *cobra.Command {
 			// based on the TTPs argument value specifications
 			ttpCfg.Repo = foundRepo
 
-			// Set the --no-cleanup value if provided
-			ttpCfg.NoCleanup, err = cmd.Flags().GetBool("no-cleanup")
-			if err != nil {
-				return fmt.Errorf("failed to process the no-cleanup arg: %v", err)
-			}
-
 			ttp, err := blocks.LoadTTP(ttpAbsPath, foundRepo.GetFs(), &ttpCfg, argsList)
 			if err != nil {
 				return fmt.Errorf("could not load TTP at %v:\n\t%v", ttpAbsPath, err)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -102,6 +102,7 @@ func TestNoCleanupFlag(t *testing.T) {
 		{
 			name: "Test No Cleanup Behavior - Directory Creation",
 			content: `
+---
 name: test-cleanup
 steps:
   - name: step_one
@@ -117,6 +118,7 @@ steps:
 		{
 			name: "Test Cleanup Behavior - Directory Deletion",
 			content: `
+---
 name: test-cleanup-2
 steps:
   - name: step_two


### PR DESCRIPTION
# Proposed Changes

This PR introduces tests and a fix for the cleanup-related functionalities in TTPForge.

## Related Issue(s)

- #259

## Testing

Three main changes were tested and added:

1. Added a test `TestCleanupDelayFlag()` to verify the behavior of the `--cleanup-delay-seconds` flag.
2. Introduced `TestNoCleanupFlag()` to validate the workings of the `--no-cleanup` flag.
3. Addressed and resolved issues with the `--no-cleanup` functionality.

All changes were committed separately for clarity and easy tracking.

## Documentation

- No documentation updates were made. Future documentation should cover the usage and testing of cleanup-related flags.

## Screenshots/GIFs (optional)

- Not applicable.

## Checklist

- [x] Ran `mage runprecommit` locally and fixed any issues that arose.
- [x] Ran `mage runtests` locally and fixed any issues that arose.
- [x] Curated your commits so they are legible and easy to read and understand.
- [x] 🚀