### PR TITLE
Add create_file step

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tidwall/gjson v1.16.0 h1:SyXa+dsSPpUlcwEDuKuEBJEz5vzTvOea+9rjyYodQFg=
-github.com/tidwall/gjson v1.16.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.17.0 h1:/Jocvlh98kcTfpN2+JzGQWQcqrPQwDrVEMApx/M5ZwM=
 github.com/tidwall/gjson v1.17.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/pkg/blocks/README.md
+++ b/pkg/blocks/README.md
@@ -214,6 +214,107 @@ Validate validates the BasicStep, checking for the necessary attributes and depe
 
 ---
 
+### CreateFileStep.Cleanup(TTPExecutionContext)
+
+```go
+Cleanup(TTPExecutionContext) *ActResult, error
+```
+
+Cleanup is a method to establish a link with the Cleanup interface.
+Assumes that the type is the cleanup step and is invoked by
+s.CleanupStep.Cleanup.
+
+---
+
+### CreateFileStep.Execute(TTPExecutionContext)
+
+```go
+Execute(TTPExecutionContext) *ExecutionResult, error
+```
+
+Execute runs the step and returns an error if any occur.
+
+---
+
+### CreateFileStep.ExplainInvalid()
+
+```go
+ExplainInvalid() error
+```
+
+ExplainInvalid returns an error message explaining why the step
+is invalid.
+
+**Returns:**
+
+error: An error message explaining why the step is invalid.
+
+---
+
+### CreateFileStep.GetCleanup()
+
+```go
+GetCleanup() []CleanupAct
+```
+
+GetCleanup returns a slice of CleanupAct if the CleanupStep is not nil.
+
+---
+
+### CreateFileStep.GetType()
+
+```go
+GetType() StepType
+```
+
+GetType returns the type of the step as StepType.
+
+---
+
+### CreateFileStep.IsNil()
+
+```go
+IsNil() bool
+```
+
+IsNil checks if the step is nil or empty and returns a boolean value.
+
+---
+
+### CreateFileStep.UnmarshalYAML(*yaml.Node)
+
+```go
+UnmarshalYAML(*yaml.Node) error
+```
+
+UnmarshalYAML decodes a YAML node into a CreateFileStep instance. It uses
+the provided struct as a template for the YAML data, and initializes the
+CreateFileStep instance with the decoded values.
+
+**Parameters:**
+
+node: A pointer to a yaml.Node representing the YAML data to decode.
+
+**Returns:**
+
+error: An error if there is a problem decoding the YAML data.
+
+---
+
+### CreateFileStep.Validate(TTPExecutionContext)
+
+```go
+Validate(TTPExecutionContext) error
+```
+
+Validate validates the step
+
+**Returns:**
+
+error: An error if any validation checks fail.
+
+---
+
 ### EditStep.Execute(TTPExecutionContext)
 
 ```go
@@ -595,6 +696,16 @@ NewBasicStep() *BasicStep
 ```
 
 NewBasicStep creates a new BasicStep instance with an initialized Act struct.
+
+---
+
+### NewCreateFileStep()
+
+```go
+NewCreateFileStep() *CreateFileStep
+```
+
+NewCreateFileStep creates a new CreateFileStep instance and returns a pointer to it.
 
 ---
 

--- a/pkg/blocks/createfile.go
+++ b/pkg/blocks/createfile.go
@@ -1,0 +1,219 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package blocks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/facebookincubator/ttpforge/pkg/logging"
+	"github.com/spf13/afero"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+// CreateFileStep creates a new file and populates it
+// with the specified contents.
+// Its intended use is simulating malicious file creation
+// through an editor program or via a C2, where there is no
+// corresponding shell history telemetry
+type CreateFileStep struct {
+	*Act        `yaml:",inline"`
+	Path        string     `yaml:"create_file,omitempty"`
+	Contents    string     `yaml:"contents,omitempty"`
+	Overwrite   bool       `yaml:"overwrite,omitempty"`
+	Mode        int        `yaml:"mode,omitempty"`
+	CleanupStep CleanupAct `yaml:"cleanup,omitempty,flow"`
+	FileSystem  afero.Fs   `yaml:"-,omitempty"`
+}
+
+// NewCreateFileStep creates a new CreateFileStep instance and returns a pointer to it.
+func NewCreateFileStep() *CreateFileStep {
+	return &CreateFileStep{
+		Act: &Act{
+			Type: StepCreateFile,
+		},
+	}
+}
+
+// UnmarshalYAML decodes a YAML node into a CreateFileStep instance. It uses
+// the provided struct as a template for the YAML data, and initializes the
+// CreateFileStep instance with the decoded values.
+//
+// **Parameters:**
+//
+// node: A pointer to a yaml.Node representing the YAML data to decode.
+//
+// **Returns:**
+//
+// error: An error if there is a problem decoding the YAML data.
+func (s *CreateFileStep) UnmarshalYAML(node *yaml.Node) error {
+
+	type createFileStepTmpl struct {
+		Act         `yaml:",inline"`
+		Path        string    `yaml:"create_file,omitempty"`
+		Contents    string    `yaml:"contents,omitempty"`
+		Overwrite   bool      `yaml:"overwrite,omitempty"`
+		Mode        int       `yaml:"mode,omitempty"`
+		CleanupStep yaml.Node `yaml:"cleanup,omitempty,flow"`
+	}
+
+	// Decode the YAML node into the provided template.
+	var tmpl createFileStepTmpl
+	if err := node.Decode(&tmpl); err != nil {
+		return err
+	}
+
+	// Initialize the instance with the decoded values.
+	s.Act = &tmpl.Act
+	s.Path = tmpl.Path
+	s.Contents = tmpl.Contents
+	s.Overwrite = tmpl.Overwrite
+	s.Mode = tmpl.Mode
+
+	// Check for invalid steps.
+	if s.IsNil() {
+		return s.ExplainInvalid()
+	}
+
+	// If there is no cleanup step or if this step is the cleanup step, exit.
+	if tmpl.CleanupStep.IsZero() || s.Type == StepCleanup {
+		return nil
+	}
+
+	// Create a CleanupStep instance and add it to this step
+	cleanup, err := s.MakeCleanupStep(&tmpl.CleanupStep)
+	if err != nil {
+		return err
+	}
+
+	s.CleanupStep = cleanup
+
+	return nil
+}
+
+// GetType returns the type of the step as StepType.
+func (s *CreateFileStep) GetType() StepType {
+	return StepCreateFile
+}
+
+// Cleanup is a method to establish a link with the Cleanup interface.
+// Assumes that the type is the cleanup step and is invoked by
+// s.CleanupStep.Cleanup.
+func (s *CreateFileStep) Cleanup(execCtx TTPExecutionContext) (*ActResult, error) {
+	result, err := s.Execute(execCtx)
+	if err != nil {
+		return nil, err
+	}
+	return &result.ActResult, err
+}
+
+// GetCleanup returns a slice of CleanupAct if the CleanupStep is not nil.
+func (s *CreateFileStep) GetCleanup() []CleanupAct {
+	if s.CleanupStep != nil {
+		return []CleanupAct{s.CleanupStep}
+	}
+	return []CleanupAct{}
+}
+
+// ExplainInvalid returns an error message explaining why the step
+// is invalid.
+//
+// **Returns:**
+//
+// error: An error message explaining why the step is invalid.
+func (s *CreateFileStep) ExplainInvalid() error {
+	if s.Path == "" {
+		return errors.New("empty `create_file:` provided")
+	}
+	return nil
+}
+
+// IsNil checks if the step is nil or empty and returns a boolean value.
+func (s *CreateFileStep) IsNil() bool {
+	switch {
+	case s.Act.IsNil():
+		return true
+	case s.Path == "":
+		return true
+	default:
+		return false
+	}
+}
+
+// Execute runs the step and returns an error if any occur.
+func (s *CreateFileStep) Execute(execCtx TTPExecutionContext) (*ExecutionResult, error) {
+	logging.L().Infof("Creating file %v", s.Path)
+	fsys := s.FileSystem
+	if fsys == nil {
+		fsys = afero.NewOsFs()
+	}
+
+	exists, err := afero.Exists(fsys, s.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	var f afero.File
+	if exists && !s.Overwrite {
+		return nil, fmt.Errorf("path %v already exists and overwrite was not set", s.Path)
+	}
+	// use the default umask
+	// https://stackoverflow.com/questions/23842247/reading-default-filemode-when-using-os-o-create
+	mode := s.Mode
+	if mode == 0 {
+		mode = 0666
+	}
+	f, err = fsys.OpenFile(s.Path, os.O_WRONLY|os.O_CREATE, os.FileMode(mode))
+	if err != nil {
+		return nil, err
+	}
+	_, err = f.Write([]byte(s.Contents))
+	if err != nil {
+		return nil, err
+	}
+
+	return &ExecutionResult{}, nil
+}
+
+// Validate validates the step
+//
+// **Returns:**
+//
+// error: An error if any validation checks fail.
+func (s *CreateFileStep) Validate(execCtx TTPExecutionContext) error {
+	if err := s.Act.Validate(); err != nil {
+		return err
+	}
+
+	if s.Path == "" {
+		return fmt.Errorf("path field cannot be empty")
+	}
+
+	if s.CleanupStep != nil {
+		if err := s.CleanupStep.Validate(execCtx); err != nil {
+			logging.L().Errorw("error validating cleanup step", zap.Error(err))
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/blocks/createfile_test.go
+++ b/pkg/blocks/createfile_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package blocks_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/facebookincubator/ttpforge/pkg/blocks"
+	"github.com/facebookincubator/ttpforge/pkg/testutils"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateFileExecute(t *testing.T) {
+	testCases := []struct {
+		name               string
+		description        string
+		step               *blocks.CreateFileStep
+		fsysContents       map[string][]byte
+		expectExecuteError bool
+	}{
+		{
+			name:        "Create Valid File",
+			description: "Create a single unremarkable file",
+			step: &blocks.CreateFileStep{
+				Path:     "valid-file.txt",
+				Contents: "hello world",
+			},
+		},
+		{
+			name:        "Nested Directories",
+			description: "Afero should handle this under the hood",
+			step: &blocks.CreateFileStep{
+				Path:     "/directory/does/not/exist",
+				Contents: "should still work",
+			},
+		},
+		{
+			name:        "Already Exists (No Overwrite)",
+			description: "Should fail because file already exists",
+			step: &blocks.CreateFileStep{
+				Path:     "already-exists.txt",
+				Contents: "will fail",
+			},
+			fsysContents: map[string][]byte{
+				"already-exists.txt": []byte("whoops"),
+			},
+			expectExecuteError: true,
+		},
+		{
+			name:        "Already Exists (With Overwrite)",
+			description: "Should succeed and overwrite existing file",
+			step: &blocks.CreateFileStep{
+				Path:      "already-exists.txt",
+				Contents:  "will succeed",
+				Overwrite: true,
+			},
+			fsysContents: map[string][]byte{
+				"already-exists.txt": []byte("whoops"),
+			},
+		},
+		{
+			name:        "Set Permissions Manually",
+			description: "Make the file read-only",
+			step: &blocks.CreateFileStep{
+				Path:     "make-read-only",
+				Contents: "very-read-only",
+				Mode:     0400,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// prep filesystem
+			if tc.fsysContents != nil {
+				fsys, err := testutils.MakeAferoTestFs(tc.fsysContents)
+				require.NoError(t, err)
+				tc.step.FileSystem = fsys
+			} else {
+				tc.step.FileSystem = afero.NewMemMapFs()
+			}
+
+			// execute and check error
+			var execCtx blocks.TTPExecutionContext
+			_, err := tc.step.Execute(execCtx)
+			if tc.expectExecuteError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// check contents
+			contentBytes, err := afero.ReadFile(tc.step.FileSystem, tc.step.Path)
+			require.NoError(t, err)
+			assert.Equal(t, tc.step.Contents, string(contentBytes))
+
+			// check permissions
+			if tc.step.Mode != 0 {
+				info, err := tc.step.FileSystem.Stat(tc.step.Path)
+				require.NoError(t, err)
+				assert.Equal(t, os.FileMode(tc.step.Mode), info.Mode())
+			}
+		})
+	}
+}

--- a/pkg/blocks/step.go
+++ b/pkg/blocks/step.go
@@ -47,13 +47,14 @@ type StepType string
 
 // Constants for defining the types of steps available.
 const (
-	StepUnset    = "unsetStep"
-	StepFile     = "fileStep"
-	StepFetchURI = "fetchURIStep"
-	StepBasic    = "basicStep"
-	StepSubTTP   = "subTTPStep"
-	StepCleanup  = "cleanupStep"
-	StepEdit     = "editStep"
+	StepCreateFile = "createFileStep"
+	StepUnset      = "unsetStep"
+	StepFile       = "fileStep"
+	StepFetchURI   = "fetchURIStep"
+	StepBasic      = "basicStep"
+	StepSubTTP     = "subTTPStep"
+	StepCleanup    = "cleanupStep"
+	StepEdit       = "editStep"
 )
 
 // Act represents a single action within a TTP (Tactics, Techniques,

--- a/pkg/blocks/ttps.go
+++ b/pkg/blocks/ttps.go
@@ -179,7 +179,7 @@ func (t *TTP) decodeSteps(steps []yaml.Node) error {
 		// these candidate steps are pointers, so this line
 		// MUST be inside the outer step loop or horrible things will happen
 		// #justpointerthings
-		stepTypes := []Step{NewBasicStep(), NewFileStep(), NewSubTTPStep(), NewEditStep(), NewFetchURIStep()}
+		stepTypes := []Step{NewBasicStep(), NewFileStep(), NewSubTTPStep(), NewEditStep(), NewFetchURIStep(), NewCreateFileStep()}
 		for _, stepType := range stepTypes {
 			err := stepNode.Decode(stepType)
 			if err == nil && !stepType.IsNil() {
@@ -200,21 +200,11 @@ func (t *TTP) decodeSteps(steps []yaml.Node) error {
 		}
 
 		if !decoded {
-			return t.handleInvalidStepError(stepNode)
+			return fmt.Errorf("Step #%v does not match any supported step type", stepIdx+1)
 		}
 	}
 
 	return nil
-}
-
-func (t *TTP) handleInvalidStepError(stepNode yaml.Node) error {
-	act := Act{}
-	err := stepNode.Decode(&act)
-
-	if act.Name != "" && err != nil {
-		return fmt.Errorf("invalid step found, missing parameters for step types")
-	}
-	return fmt.Errorf("invalid step found with no name, missing parameters for step types")
 }
 
 func (t *TTP) setWorkingDirectory() error {


### PR DESCRIPTION
Supporting this step type makes "drop malicious script in `/var/www/...`", "write malicious config to `/etc/sudoers.d/`"  much more ergonomic and allows higher-fidelity telemetry where you don't pop a shell unless it is necessary to do so