### PR TITLE
Bugfix: Templates Using HTML Rendering not Text Rendering

### DIFF
--- a/pkg/blocks/loader.go
+++ b/pkg/blocks/loader.go
@@ -22,11 +22,11 @@ package blocks
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"text/template"
 
 	"github.com/facebookincubator/ttpforge/pkg/args"
 	"github.com/facebookincubator/ttpforge/pkg/preprocess"

--- a/pkg/blocks/ttps_test.go
+++ b/pkg/blocks/ttps_test.go
@@ -287,6 +287,25 @@ steps:
 			},
 			wantError: false,
 		},
+		{
+			name: "Metacharacters in step contents",
+			content: `name: test_metacharacters
+steps:
+  - name: step1
+    inline: |
+      cat <<EOF
+      A
+      B
+      EOF`,
+			execConfig: blocks.TTPExecutionConfig{},
+			expectedByIndexOut: map[int]string{
+				0: "A\nB\n",
+			},
+			expectedByNameOut: map[string]string{
+				"step1": "A\nB\n",
+			},
+			wantError: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
So much sorrow from the IDE automatically adding the import for template as `html/template` instead of `text/template` and 
my not catching it - sigh: 

https://github.com/facebookincubator/TTPForge/pull/223/files#diff-578f6817d723331b92b7b339b9beec020c14b45160c0857c4ef22dbf62ac042fR25

Fixed now 