### PR TITLE
Remove twinvega codeowner to stop spam

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-* @l50 @d3sch41n @cedowens @godlovepenn @twinvega
+* @l50 @d3sch41n @cedowens @godlovepenn


### PR DESCRIPTION
@twinvega this should stop your notification spam - you can always have someone re-add you if you want these privileges in the future  