### PR TITLE
Add additional example TTPs

### DIFF
--- a/example-ttps/actions/create_file/basic.yaml
+++ b/example-ttps/actions/create_file/basic.yaml
@@ -1,0 +1,22 @@
+---
+name: create_file_basic
+description: |
+  This TTP shows you how to use the create_file action type
+  to create files on disk
+steps:
+  - name: create-first-tmp-file
+    create_file: /tmp/ttpforge_create_file_{{randAlphaNum 10}}
+    contents: |
+      Using create_file is a convenient to simulate TTPs that
+      drop files to disk. We can control the permission mode
+      with which the file is created using `mode:`
+    mode: 0600
+    cleanup: default
+  - name:  create-second-tmp-file
+    create_file: /tmp/ttpforge_create_file_overwritable
+    contents: |
+      This step uses `overwrite: true` which means
+      that even if the target file already exists, it will be overwritten with these
+      contents
+    overwrite: true
+    cleanup: default

--- a/example-ttps/actions/edit_file/append_delete.yaml
+++ b/example-ttps/actions/edit_file/append_delete.yaml
@@ -1,0 +1,34 @@
+---
+name: edit_file_append_delete
+description: |
+  Learn how to append and delete lines
+  with the edit_file action.
+args:
+  - name: test_file_path
+    description: The path at which the temporary test file should be created
+    default: /tmp/ttpforge_edit_file_append_delete
+steps:
+  - name: create-tmp-file
+    create_file: {{.Args.test_file_path}}
+    contents: |
+      this_will_be_deleted
+      and also this_will_be_deleted
+      this will survive
+      // all of these
+      // lines will be
+      // deleted by a regexp
+      and this will also survive
+    overwrite: true
+  - name: edit_test_file
+    edit_file: {{.Args.test_file_path}}
+    edits:
+      - description: |
+          Delete all occurrences of a string literal
+        delete: this_will_be_deleted
+      - description: You can also delete regular expressions matches
+        delete: (?m://.*$)
+        regexp: true
+      - description: Append a line to the file
+        append: this will be appended to the end of the file
+  - name: display_result
+    inline: cat {{.Args.test_file_path}}

--- a/example-ttps/actions/edit_file/replace.yaml
+++ b/example-ttps/actions/edit_file/replace.yaml
@@ -1,0 +1,46 @@
+---
+name: edit_file_replace
+description: |
+  This TTP shows you how to use the edit_file action type
+  to modify files and replace string literals
+  or regexp matches with new strings
+args:
+  - name: test_file_path
+    description: The path at which the temporary test file should be created
+    default: /tmp/ttpforge_edit_file_replace
+steps:
+  - name: create-tmp-file
+    create_file: {{.Args.test_file_path}}
+    contents: |
+      this_will_be_replaced
+      and another this_will_be_replaced
+      multi-line strings can
+      also be replaced
+      you can comment out entire sections using capture groups
+      entire_function_call(
+        'this function call will be commented out'
+      );
+    overwrite: true
+  - name: edit_test_file
+    edit_file: {{.Args.test_file_path}}
+    edits:
+      - description: |
+          Replace all occurrences of a string literal
+          with another string literal.
+        old: this_will_be_replaced
+        new: single_line_literal_replacement
+      - description: Same as above, but with multiple lines.
+        old: |
+          multi-line strings can
+          also be replaced
+        new: |
+          isn't that
+          cool
+      - description: |
+          You can do fancy edits with regular expressions,
+          like commenting out entire function calls in code.
+        old: (?P<fn_call>(?ms:^entire_function_call\(.*?\);$))
+        new: "/*${fn_call}*/"
+        regexp: true
+  - name: display_result
+    inline: cat {{.Args.test_file_path}}

--- a/example-ttps/actions/inline/basic.yaml
+++ b/example-ttps/actions/inline/basic.yaml
@@ -1,0 +1,21 @@
+---
+name: inline_basic
+description: |
+  This TTP shows you how to use the inline action type to
+  run basic shell commands.
+steps:
+  - name: one_line_demo
+    inline: echo 'By default, `inline:` will pass commands that you specify to `bash`'
+  - name: multi_line_demo
+    inline: |
+      echo "You can use multi_line YAML strings like this"
+      echo "To specify multiple commands."
+      echo "TTPForge will execute all of the commands that you specify,"
+      echo "rather like a shell script."
+  - name: changing_executor
+    executor: python3
+    inline: |
+      msg = """You can change the `executor:` field to
+      pass your `inline:` input to a different program.
+      This example will be executed by `python3`"""
+      print(msg)

--- a/pkg/blocks/createfile.go
+++ b/pkg/blocks/createfile.go
@@ -86,7 +86,7 @@ func (s *CreateFileStep) Execute(execCtx TTPExecutionContext) (*ActResult, error
 	}
 
 	// actually write the file
-	f, err := fsys.OpenFile(pathToCreate, os.O_WRONLY|os.O_CREATE, os.FileMode(mode))
+	f, err := fsys.OpenFile(pathToCreate, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(mode))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Summary:
* Bugfix create_file so that `overwrite` works correctly
* Add example TTPs for action types:
  * inline
  * create_file
  * edit_file

Differential Revision: D51439700


