### PR TITLE
Bugfix (minor): Fix Unit Test Config Handling and Config Marshal/Unmarshal

### DIFF
--- a/cmd/removerepo.go
+++ b/cmd/removerepo.go
@@ -43,8 +43,8 @@ func buildRemoveRepoCommand(cfg *Config) *cobra.Command {
 			}
 
 			// delete the repo files
-			logging.L().Infof("deleting repo files", repoToRemove)
 			fp := r.GetFullPath()
+			logging.L().Infof("deleting files for repo %q (path: %v)...", repoToRemove, fp)
 			err = afero.NewOsFs().RemoveAll(fp)
 			if err != nil {
 				return err
@@ -59,12 +59,12 @@ func buildRemoveRepoCommand(cfg *Config) *cobra.Command {
 				newRepoSpecs = append(newRepoSpecs, spec)
 			}
 			cfg.RepoSpecs = newRepoSpecs
-			logging.L().Infof("writing updated configuration...", repoToRemove)
+			logging.L().Info("writing updated configuration...")
 			err = cfg.save()
 			if err != nil {
 				return fmt.Errorf("failed to save updated configuration: %v", err)
 			}
-			logging.L().Infof("repo %v deleted successfully", repoToRemove)
+			logging.L().Infof("repo %q deleted successfully", repoToRemove)
 
 			// remove the repo reference from the configuration file
 			return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,9 +40,9 @@ import (
 // **Returns:**
 //
 // *cobra.Command: The initialized root cobra command
-func BuildRootCommand(cfg *Config) *cobra.Command {
-	if cfg == nil {
-		cfg = &Config{}
+func BuildRootCommand(testCfg *TestConfig) *cobra.Command {
+	cfg := &Config{
+		testCfg: testCfg,
 	}
 
 	// setup root command and flags

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -39,7 +39,9 @@ func buildRunCommand(cfg *Config) *cobra.Command {
 			cmd.SilenceUsage = true
 
 			// capture output for tests if needed
-			ttpCfg.Stdout, ttpCfg.Stderr = cfg.Stdout, cfg.Stderr
+			if cfg.testCfg != nil {
+				ttpCfg.Stdout, ttpCfg.Stderr = cfg.testCfg.Stdout, cfg.testCfg.Stderr
+			}
 
 			// find the TTP file
 			ttpRef := args[0]

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -128,7 +128,7 @@ func TestRun(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var stdoutBuf, stderrBuf bytes.Buffer
-			rc := BuildRootCommand(&Config{
+			rc := BuildRootCommand(&TestConfig{
 				Stdout: &stdoutBuf,
 				Stderr: &stderrBuf,
 			})


### PR DESCRIPTION
Summary:
* Fix a couple bugs that only show up in tests under certain condition, not in production usage of the tool:
    * Tests no longer read from the default configuration file
    * Test settings are no longer stored in exported fields of the Config object, meaning that they won't accidentally be marshalled into `~/.ttpforge/config.yaml` when running `install` or `remove` - this didn't cause problems for non-unit-test runs but better safe than sorry
* Polish `remove` command output format

Differential Revision: D51457037


