### PR TITLE
Add `ttpforge test` Command for Scalable Integration Testing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,6 +74,7 @@ TTPForge is a Purple Team engagement tool to execute Tactics, Techniques, and Pr
 	rootCmd.AddCommand(buildListCommand(cfg))
 	rootCmd.AddCommand(buildShowCommand(cfg))
 	rootCmd.AddCommand(buildRunCommand(cfg))
+	rootCmd.AddCommand(buildTestCommand(cfg))
 	rootCmd.AddCommand(buildInstallCommand(cfg))
 	rootCmd.AddCommand(buildRemoveCommand(cfg))
 	return rootCmd

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,127 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/facebookincubator/ttpforge/pkg/logging"
+	"github.com/facebookincubator/ttpforge/pkg/preprocess"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+type testCase struct {
+	Name   string            `yaml:"name"`
+	Args   map[string]string `yaml:"args"`
+	DryRun bool              `yaml:"dry_run"`
+}
+
+type testSection struct {
+	Cases []testCase `yaml:"tests"`
+}
+
+func buildTestCommand(cfg *Config) *cobra.Command {
+	var timeoutSeconds int
+	runCmd := &cobra.Command{
+		Use:   "test [repo_name//path/to/ttp]",
+		Short: "Test the TTP found in the specified YAML file.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// don't want confusing usage display for errors past this point
+			cmd.SilenceUsage = true
+
+			// find the TTP file
+			ttpRef := args[0]
+			_, ttpAbsPath, err := cfg.repoCollection.ResolveTTPRef(ttpRef)
+			if err != nil {
+				return fmt.Errorf("failed to resolve TTP reference %v: %w", ttpRef, err)
+			}
+
+			// preprocess to separate out the `tests:` section from the `steps:`
+			// section and avoid YAML parsing errors associated with template syntax
+			contents, err := afero.ReadFile(afero.NewOsFs(), ttpAbsPath)
+			if err != nil {
+				return fmt.Errorf("failed to read TTP file %v: %w", ttpAbsPath, err)
+			}
+			preprocessResult, err := preprocess.Parse(contents)
+			if err != nil {
+				return err
+			}
+
+			// load the test cases
+			var ts testSection
+			err = yaml.Unmarshal(preprocessResult.PreambleBytes, &ts)
+			if err != nil {
+				return fmt.Errorf("failed to parse `test:` section of TTP file %v: %w", ttpAbsPath, err)
+			}
+
+			// look up the path of this binary (ttpforge)
+			selfPath, err := os.Executable()
+			if err != nil {
+				return fmt.Errorf("could not resolve self path (path to current ttpforge binary): %w", err)
+			}
+
+			if len(ts.Cases) == 0 {
+				logging.L().Warnf("No tests defined in TTP file %v; exiting...", ttpAbsPath)
+				return nil
+			}
+
+			// run all cases
+			logging.DividerThick()
+			logging.L().Infof("EXECUTING %v TEST CASE(S)", len(ts.Cases))
+			for tcIdx, tc := range ts.Cases {
+				logging.DividerThin()
+				logging.L().Infof("RUNNING TEST CASE #%d: %q", tcIdx+1, tc.Name)
+				logging.DividerThin()
+				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, selfPath)
+				cmd.Args = append(cmd.Args, "run", ttpAbsPath)
+				for argName, argVal := range tc.Args {
+					cmd.Args = append(cmd.Args, "--arg")
+					cmd.Args = append(cmd.Args, argName+"="+argVal)
+				}
+				if tc.DryRun {
+					cmd.Args = append(cmd.Args, "--dry-run")
+				}
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+
+				err = cmd.Run()
+				if err != nil {
+					return fmt.Errorf("test case %q failed: %w", tc.Name, err)
+				}
+			}
+			logging.DividerThick()
+			logging.L().Info("ALL TESTS COMPLETED SUCCESSFULLY!")
+			return nil
+		},
+	}
+	runCmd.PersistentFlags().IntVar(&timeoutSeconds, "time-out-seconds", 10, "Timeout allowed for each test case")
+
+	return runCmd
+}

--- a/example-ttps/tests/dry_run.yaml
+++ b/example-ttps/tests/dry_run.yaml
@@ -1,0 +1,30 @@
+---
+name: Test Case with Dry Run
+description: |
+  This TTP illustrates the impact of the `dry_run` field
+  on the behavior of a test case. When `dry_run` is set
+  to `true`, the `--dry-run` flag will be appended
+  to the `ttpforge run` command that is constructed to execute
+  the test case. This means that the TTP will be validated
+  (after full template rendering) but not executed.
+tests:
+  - name: default
+    dry_run: true
+    # note that we still need to specify
+    # a valid set of arguments!
+    args:
+      file_suffix: wut
+args:
+  - name: file_suffix
+    description: the suffix to append to the created file
+steps:
+  # this contrived TTP would only work on a very specific system
+  # for which this path exists. We still want the validate
+  # that THIS YAML FILE ITSELF is a valid TTP that COULD
+  # run under the right conditions, so we specify `dry_run: true`
+  # in the test case.
+  - name: create_very_specific_file
+    create_file: /very/specific/path/test-{{.Args.file_suffix}}
+    contents: foo
+    overwrite: true
+    cleanup: default

--- a/example-ttps/tests/minimal_test_case.yaml
+++ b/example-ttps/tests/minimal_test_case.yaml
@@ -1,0 +1,14 @@
+---
+name: Minimal Test Case Example for `tests:` Feature
+description: |
+  This TTP illustrates the simplest possible valid test case
+  within its `tests:` section. When the tests for
+  this TTP are executed using the `ttpforge test` command,
+  the single test case `default` will be executed. This will
+  cause `ttpforge run` to be executed against this TTP
+  YAML file and the resulting exit status will be checked.
+tests:
+  - name: default
+steps:
+  - name: placeholder-step
+    print_str: "I am a placeholder to show off the `tests:` feature."

--- a/example-ttps/tests/with_args.yaml
+++ b/example-ttps/tests/with_args.yaml
@@ -1,0 +1,41 @@
+---
+name: Multiple Test Cases with Arguments
+description: |
+  This TTP illustrates how to use the `tests` feature
+  to define multiple more complex test cases that rely on
+  command-line arguments.
+tests:
+  - name: yes_cat_file
+    args:
+      target_file_path: /tmp/ttpforge_tests_example_yes_cat
+      # note the use of YAML block chomping via the '|-'
+      # so that our template renders correctly
+      # (see: https://yaml-multiline.info/)
+      contents: |-
+        this will be printed to the screen.
+        we deliberately chose a multiline string
+        to verify correct handling in arg string construction.
+      should_cat_file: true
+  - name: no_cat_file
+    args:
+      target_file_path: /tmp/ttpforge_tests_example_no_cat
+      contents: this will not be printed
+args:
+  - name: target_file_path
+    description: the path of the file to create
+  - name: contents
+    description: the contents to write to the target file
+  - name: should_cat_file
+    type: bool
+    default: false
+steps:
+  - name: create_a_file
+    create_file: {{.Args.target_file_path}}
+    contents: |
+{{indent 6 .Args.contents}}
+    overwrite: true
+    cleanup: default
+  {{ if .Args.should_cat_file -}}
+  - name: cat_file
+    inline: cat {{.Args.target_file_path}}
+  {{ end }}

--- a/pkg/blocks/loader.go
+++ b/pkg/blocks/loader.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/facebookincubator/ttpforge/pkg/args"
+	"github.com/facebookincubator/ttpforge/pkg/logging"
 	"github.com/facebookincubator/ttpforge/pkg/preprocess"
 	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
@@ -66,6 +67,11 @@ func RenderTemplatedTTP(ttpStr string, execCfg *TTPExecutionConfig) (*TTP, error
 	var ttp TTP
 	err = yaml.Unmarshal(result.Bytes(), &ttp)
 	if err != nil {
+		// important - errors from template rendering are often
+		// opaque so we need to log the real thing
+		logging.L().Errorf("failed to decode TTP YAML - received error: %v", err)
+		logging.L().Error("inspect the rendered TTP below (with all templates such as `{{.Args.foo}}` expanded):\n", result.String())
+		logging.DividerThin()
 		return nil, err
 	}
 	return &ttp, nil

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -51,6 +51,18 @@ func L() *zap.SugaredLogger {
 	return logger
 }
 
+// DividerThick prints a divider line made of `=` characters
+// to help with the readability of logs
+func DividerThick() {
+	L().Infow("========================================")
+}
+
+// DividerThin prints a divider line made of `-` characters
+// to help with the readability of logs
+func DividerThin() {
+	L().Infow("----------------------------------------")
+}
+
 // InitLog initializes TTPForge global logger
 func InitLog(config Config) (err error) {
 	zcfg := zap.NewDevelopmentConfig()


### PR DESCRIPTION
Summary:
* add a new top-level cobra command, `ttpforge test`, that runs integration tests cases defined directly within TTPForge YAML files
* under the hood, this calls `ttpforge run` with the actual ttpforge binary
* added several example TTPs that will be included in docs (they need to land in github first so that code snippets will work on the subsequent docs commit)

Differential Revision: D51458305


