### PR TITLE
Move dry-run to a better location

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/facebookincubator/ttpforge/pkg/blocks"
+	"github.com/facebookincubator/ttpforge/pkg/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -54,6 +55,11 @@ func buildRunCommand(cfg *Config) *cobra.Command {
 			ttp, execCtx, err := blocks.LoadTTP(ttpAbsPath, foundRepo.GetFs(), &ttpCfg, argsList)
 			if err != nil {
 				return fmt.Errorf("could not load TTP at %v:\n\t%v", ttpAbsPath, err)
+			}
+
+			if ttpCfg.DryRun {
+				logging.L().Info("Dry-Run Requested - Returning Early")
+				return nil
 			}
 
 			if _, err := ttp.Execute(execCtx); err != nil {

--- a/pkg/blocks/ttps.go
+++ b/pkg/blocks/ttps.go
@@ -252,11 +252,6 @@ func (t *TTP) RunSteps(execCtx *TTPExecutionContext) (*StepResultsRecord, int, e
 	}
 	defer changeBack()
 
-	if execCtx.Cfg.DryRun {
-		logging.L().Info("[*] Dry-Run Requested - Returning Early")
-		return nil, -1, nil
-	}
-
 	// actually run all the steps
 	logging.L().Infof("[+] Running current TTP: %s", t.Name)
 	stepResults := NewStepResultsRecord()


### PR DESCRIPTION
Summary: The dry-run feature (which becomes essential for integration tests in (D51458305) should live further up the to prevent mistakes.

Differential Revision: D51459508


