### PR TITLE
Refactor `pkg/args` Tests To Reduce Giant Test Case Size

### DIFF
--- a/pkg/args/choices.go
+++ b/pkg/args/choices.go
@@ -1,0 +1,47 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package args
+
+func (spec Spec) validateChoiceTypes() error {
+	if len(spec.Choices) == 0 {
+		return nil
+	}
+
+	for _, choice := range spec.Choices {
+		_, err := spec.convertArgToType(choice)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (spec Spec) isValidChoice(value string) bool {
+	if len(spec.Choices) == 0 {
+		return true
+	}
+
+	for _, choice := range spec.Choices {
+		if choice == value {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/args/choices_test.go
+++ b/pkg/args/choices_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package args
+
+import (
+	"testing"
+)
+
+func TestValidateArgsChoices(t *testing.T) {
+
+	testCases := []validateTestCase{
+		{
+			name: "Choices: Argument Value is a Valid Choice",
+			specs: []Spec{
+				{
+					Name:    "alpha",
+					Choices: []string{"foo", "bar"},
+				},
+			},
+			argKvStrs: []string{
+				"alpha=bar",
+			},
+			expectedResult: map[string]any{
+				"alpha": "bar",
+			},
+			wantError: false,
+		},
+		{
+			name: "Choices: Default Value is Not a Valid Choice",
+			specs: []Spec{
+				{
+					Name:    "alpha",
+					Choices: []string{"foo", "bar"},
+					Default: "baz",
+				},
+			},
+			argKvStrs: []string{
+				"alpha=bar",
+			},
+			wantError: true,
+		},
+		{
+			name: "Choices: Argument Value is Not a Valid Choice",
+			specs: []Spec{
+				{
+					Name:    "alpha",
+					Choices: []string{"foo", "bar"},
+				},
+			},
+			argKvStrs: []string{
+				"alpha=baz",
+			},
+			wantError: true,
+		},
+		{
+			name: "Choices: Testing Type Generality (int)",
+			specs: []Spec{
+				{
+					Name:    "alpha",
+					Type:    "int",
+					Choices: []string{"1", "2"},
+				},
+			},
+			argKvStrs: []string{
+				"alpha=1",
+			},
+			expectedResult: map[string]any{
+				"alpha": 1,
+			},
+			wantError: false,
+		},
+		{
+			name: "Choices: Choice Configuration Contains Value with Incorrect Type",
+			specs: []Spec{
+				{
+					Name:    "alpha",
+					Type:    "int",
+					Choices: []string{"CECI_NEST_PAS_UNE_INT", "1", "2"},
+				},
+			},
+			argKvStrs: []string{
+				"alpha=2",
+			},
+			wantError: true,
+		},
+		{
+			name: "Choices: Wrong Type in Choice Configuration and Wrong Argument Type",
+			specs: []Spec{
+				{
+					Name:    "alpha",
+					Type:    "int",
+					Choices: []string{"1", "2", "CECI_NEST_PAS_UNE_INT"},
+				},
+			},
+			argKvStrs: []string{
+				"alpha=CECI_NEST_PAS_UNE_INT",
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			checkValidateTestCase(t, tc)
+		})
+	}
+
+}

--- a/pkg/args/spec.go
+++ b/pkg/args/spec.go
@@ -150,33 +150,6 @@ func ParseAndValidate(specs []Spec, argsKvStrs []string) (map[string]any, error)
 	return processedArgs, nil
 }
 
-func (spec Spec) validateChoiceTypes() error {
-	if len(spec.Choices) == 0 {
-		return nil
-	}
-
-	for _, choice := range spec.Choices {
-		_, err := spec.convertArgToType(choice)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (spec Spec) isValidChoice(value string) bool {
-	if len(spec.Choices) == 0 {
-		return true
-	}
-
-	for _, choice := range spec.Choices {
-		if choice == value {
-			return true
-		}
-	}
-	return false
-}
-
 func (spec Spec) convertArgToType(val string) (any, error) {
 	switch spec.Type {
 	case "", "string":

--- a/pkg/args/spec_test.go
+++ b/pkg/args/spec_test.go
@@ -26,15 +26,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type validateTestCase struct {
+	name           string
+	specs          []Spec
+	argKvStrs      []string
+	expectedResult map[string]any
+	wantError      bool
+}
+
+func checkValidateTestCase(t *testing.T, tc validateTestCase) {
+	args, err := ParseAndValidate(tc.specs, tc.argKvStrs)
+	if tc.wantError {
+		require.Error(t, err)
+		return
+	}
+	require.NoError(t, err)
+	assert.Equal(t, tc.expectedResult, args)
+}
+
 func TestValidateArgs(t *testing.T) {
 
-	testCases := []struct {
-		name           string
-		specs          []Spec
-		argKvStrs      []string
-		expectedResult map[string]any
-		wantError      bool
-	}{
+	testCases := []validateTestCase{
 		{
 			name: "Parse String and Integer Arguments",
 			specs: []Spec{
@@ -191,94 +203,6 @@ func TestValidateArgs(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name: "Choices: expected value",
-			specs: []Spec{
-				{
-					Name:    "alpha",
-					Choices: []string{"foo", "bar"},
-				},
-			},
-			argKvStrs: []string{
-				"alpha=bar",
-			},
-			expectedResult: map[string]any{
-				"alpha": "bar",
-			},
-			wantError: false,
-		},
-		{
-			name: "Choices: wrong default value",
-			specs: []Spec{
-				{
-					Name:    "alpha",
-					Choices: []string{"foo", "bar"},
-					Default: "baz",
-				},
-			},
-			argKvStrs: []string{
-				"alpha=bar",
-			},
-			wantError: true,
-		},
-		{
-			name: "Choices: wrong argument value",
-			specs: []Spec{
-				{
-					Name:    "alpha",
-					Choices: []string{"foo", "bar"},
-				},
-			},
-			argKvStrs: []string{
-				"alpha=baz",
-			},
-			wantError: true,
-		},
-		{
-			name: "Choices: with int argument type",
-			specs: []Spec{
-				{
-					Name:    "alpha",
-					Type:    "int",
-					Choices: []string{"1", "2"},
-				},
-			},
-			argKvStrs: []string{
-				"alpha=1",
-			},
-			expectedResult: map[string]any{
-				"alpha": 1,
-			},
-			wantError: false,
-		},
-		{
-			name: "Choices: with wrong choice type",
-			specs: []Spec{
-				{
-					Name:    "alpha",
-					Type:    "int",
-					Choices: []string{"CECI_NEST_PAS_UNE_INT", "1", "2"},
-				},
-			},
-			argKvStrs: []string{
-				"alpha=2",
-			},
-			wantError: true,
-		},
-		{
-			name: "Choices: with wrong argument type",
-			specs: []Spec{
-				{
-					Name:    "alpha",
-					Type:    "int",
-					Choices: []string{"1", "2", "CECI_NEST_PAS_UNE_INT"},
-				},
-			},
-			argKvStrs: []string{
-				"alpha=CECI_NEST_PAS_UNE_INT",
-			},
-			wantError: true,
-		},
-		{
 			name: "Format with valid value",
 			specs: []Spec{
 				{
@@ -344,13 +268,7 @@ func TestValidateArgs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			args, err := ParseAndValidate(tc.specs, tc.argKvStrs)
-			if tc.wantError {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tc.expectedResult, args)
+			checkValidateTestCase(t, tc)
 		})
 	}
 


### PR DESCRIPTION
Summary:
* Start breaking giant args validation test down into smaller test cases that are grouped by area - `choices` is the first area
* Going to use this diff in the developer documentation as an example of how
   to handle the lifecycle of table-based tests as they grow

Reviewed By: nicolagiacchetta

Differential Revision: D51467408


