### PR TITLE
go.mod: remove unnecessary replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,5 +36,3 @@ require (
 	golang.org/x/text v0.9.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
-
-replace github.com/spf13/afero => github.com/spf13/afero v1.2.1


### PR DESCRIPTION
Summary: We don't need this anymore now that we have native buck build support

Differential Revision: D51498587


