### PR TITLE
Document the `tests` Feature and Demo Integration Test Runner

### DIFF
--- a/docs/foundations/README.md
+++ b/docs/foundations/README.md
@@ -5,5 +5,6 @@ Learn about the key features of TTPForge, including:
 - [Automating Attacker Actions with TTPForge](actions.md)
 - [Customizing TTPs with Command-Line Arguments](args.md)
 - [Ensuring Reliable TTP Cleanup](cleanup.md)
+- [Writing Tests for TTPs](tests.md)
 
 More sections coming soon!

--- a/docs/foundations/tests.md
+++ b/docs/foundations/tests.md
@@ -1,0 +1,49 @@
+# Tests for TTPs
+
+You can write tests for your TTPs using the `tests:` section of a TTPForge YAML
+file. These tests serve two purposes:
+
+- They act as continuously-validated documentation for how users should run your
+  TTP.
+- They help ensure that the TTPForge engine will remain compatible with your TTP
+  and provide warning if this compatibility is broken for any reason.
+
+## Basic Test Cases
+
+The simplest-possible test case that you can define for a TTP is shown below:
+
+https://github.com/facebookincubator/TTPForge/blob/bf2fbb3312a227323d1930ba500b76f041329ca2/example-ttps/tests/minimal_test_case.yaml#L1-L14
+
+When you run the test cases for this TTP via the command
+`ttpforge test examples//tests/minimal_test_case.yaml`, TTPForge will call
+`ttpforge run` and pass the absolute path to your TTP file as an argument. In
+this instance, the `tests` syntax may seem superfluous, but even in this simple
+case it plays a very important role: **by declaring a test case, you are telling
+TTPForge that your TTP is safe to run as an automated test.**
+
+## Test Cases with Arguments
+
+The `tests` feature really starts to show its value when used for TTPs that
+expect command-line arguments. An example of such a TTP, with two associated
+test cases, is shown below:
+
+https://github.com/facebookincubator/TTPForge/blob/bf2fbb3312a227323d1930ba500b76f041329ca2/example-ttps/tests/with_args.yaml#L1-L42
+
+When you test this TTP via `ttpforge test examples//tests/with_args.yaml`, both
+of the test cases in the above file will be run sequentially. TTPForge will
+parse the provided `args` list, encode each entry in the string format
+`--arg foo=bar`, and then append each resulting string to a dynamically
+generated `ttpforge run` command. The subsequent execution of that command
+verifies that the TTP functions correctly for that test case.
+
+## Dry-Run Test Cases
+
+Some TTPs can only be executed except under very specific conditions - for
+example, Active Directory exploits that target domain controllers. It may not be
+feasible to test execution of such a TTP in an automated setting; however, it is
+still possible to verify that the TTP parses its arguments correctly and that
+all TTPForge validation phases _prior to actual execution_ complete
+successfully. To perform "validation without execution" in this manner, add
+`dry_run: true` to your test case, as shown below:
+
+https://github.com/facebookincubator/TTPForge/blob/bf2fbb3312a227323d1930ba500b76f041329ca2/example-ttps/tests/dry_run.yaml#L1-L30

--- a/example-ttps/introduction/dotfile-backdoor-demo.yaml
+++ b/example-ttps/introduction/dotfile-backdoor-demo.yaml
@@ -8,7 +8,8 @@ description: |
     - Checking Conditions at Runtime to Avoid Errors
 tests:
   - name: default
-    description: execute with the default setting
+    description: dry run with the default settings
+    dry_run: true
 args:
   - name: target_file_path
     type: path

--- a/run_all_ttp_tests.sh
+++ b/run_all_ttp_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+"$1" test example-ttps/**/*.yaml


### PR DESCRIPTION
Summary:
* Add documentation for the `tests` feature
* Allow `ttpforge test` to accept multiple arguments
* Create a demo integration test runner that works in fbcode via buck2 custom_unittest - will rebase on D51518892 and build on that integration test script

Reviewed By: cedowens

Differential Revision: D51520434


