### PR TITLE
💡 [REQUEST] - Add Default Cleanup Action to `edit_file`

### DIFF
--- a/pkg/blocks/copypath.go
+++ b/pkg/blocks/copypath.go
@@ -33,12 +33,13 @@ import (
 // via a C2, where there is no corresponding shell history
 // telemetry.
 type CopyPathStep struct {
-	Source      string   `yaml:"copy_path,omitempty"`
-	Destination string   `yaml:"to,omitempty"`
-	Recursive   bool     `yaml:"recursive,omitempty"`
-	Overwrite   bool     `yaml:"overwrite,omitempty"`
-	Mode        int      `yaml:"mode,omitempty"`
-	FileSystem  afero.Fs `yaml:"-,omitempty"`
+	actionDefaults `yaml:"-"`
+	Source         string   `yaml:"copy_path,omitempty"`
+	Destination    string   `yaml:"to,omitempty"`
+	Recursive      bool     `yaml:"recursive,omitempty"`
+	Overwrite      bool     `yaml:"overwrite,omitempty"`
+	Mode           int      `yaml:"mode,omitempty"`
+	FileSystem     afero.Fs `yaml:"-,omitempty"`
 }
 
 // NewCopyPathStep creates a new CopyPathStep instance and returns a pointer to it.
@@ -146,6 +147,11 @@ func (s *CopyPathStep) GetDefaultCleanupAction() Action {
 	return &RemovePathAction{
 		Path: s.Destination,
 	}
+}
+
+// CanBeUsedInCompositeAction indicates whether this step can be used as part of a composite action.
+func (s *CopyPathStep) CanBeUsedInCompositeAction() bool {
+	return true
 }
 
 // Validate validates the step

--- a/pkg/blocks/createfile.go
+++ b/pkg/blocks/createfile.go
@@ -34,11 +34,12 @@ import (
 // through an editor program or via a C2, where there is no
 // corresponding shell history telemetry
 type CreateFileStep struct {
-	Path       string   `yaml:"create_file,omitempty"`
-	Contents   string   `yaml:"contents,omitempty"`
-	Overwrite  bool     `yaml:"overwrite,omitempty"`
-	Mode       int      `yaml:"mode,omitempty"`
-	FileSystem afero.Fs `yaml:"-,omitempty"`
+	actionDefaults `yaml:"-"`
+	Path           string   `yaml:"create_file,omitempty"`
+	Contents       string   `yaml:"contents,omitempty"`
+	Overwrite      bool     `yaml:"overwrite,omitempty"`
+	Mode           int      `yaml:"mode,omitempty"`
+	FileSystem     afero.Fs `yaml:"-,omitempty"`
 }
 
 // NewCreateFileStep creates a new CreateFileStep instance and returns a pointer to it.

--- a/pkg/blocks/editstep_test.go
+++ b/pkg/blocks/editstep_test.go
@@ -303,11 +303,13 @@ edits:
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedContentsAfterEdit, string(contents))
+
 			if editStep.BackupFile != "" {
 				backupContents, err := afero.ReadFile(editStep.FileSystem, editStep.BackupFile)
 				require.NoError(t, err)
 				assert.Equal(t, originalContent, backupContents)
 			}
+
 		})
 	}
 }

--- a/pkg/blocks/removepath.go
+++ b/pkg/blocks/removepath.go
@@ -102,3 +102,8 @@ func (s *RemovePathAction) Validate(execCtx TTPExecutionContext) error {
 	}
 	return nil
 }
+
+// CanBeUsedInCompositeAction returns whether this action can be used as part of a composite step
+func (s *RemovePathAction) CanBeUsedInCompositeAction() bool {
+	return true
+}

--- a/pkg/blocks/subttp.go
+++ b/pkg/blocks/subttp.go
@@ -28,8 +28,9 @@ import (
 
 // SubTTPStep represents a step within a parent TTP that references a separate TTP file.
 type SubTTPStep struct {
-	TtpFile string            `yaml:"ttp"`
-	Args    map[string]string `yaml:"args"`
+	actionDefaults `yaml:"-"`
+	TtpFile        string            `yaml:"ttp"`
+	Args           map[string]string `yaml:"args"`
 
 	ttp                   *TTP
 	subExecCtx            TTPExecutionContext


### PR DESCRIPTION
Summary:
Used the `copy_path` action to implement a default cleanup action for `edit_file` that copies the backup file to the original file location.

When `backup_file` is not specified the default backup file is a temporary file.

Differential Revision: D51500512


