### PR TITLE
Documentation Update: Typos and Default Cleanup

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -8,7 +8,7 @@ and follow along.
 
 ## Install Golang
 
-TTPForge is build and tested in
+TTPForge is tested and built in
 [Github Actions](https://github.com/features/actions) using the Golang version
 from this configuration file:
 
@@ -57,7 +57,7 @@ Several of the linters in this project may be used as pre-commit hooks if
 desired - you can install and setup pre-commit according to the
 [official instructions](https://pre-commit.com/).
 
-For quick ad hoc runs, you may with to run pre-commit in a virtual environment:
+For quick ad hoc runs, you may wish to run pre-commit in a virtual environment:
 
 ```bash
 python3 -m venv venv

--- a/docs/foundations/actions/create_file.md
+++ b/docs/foundations/actions/create_file.md
@@ -30,3 +30,6 @@ You can specify the following YAML fields for the `create_file:` action:
 - `overwrite:` (type: `bool`) whether the file should be overwritten if it
   already exists.
 - `mode:` the octal permission mode (`chmod` style) for the new file.
+- `cleanup:` you can set this to `default` in order to automatically cleanup the
+  created file, or define a custom
+  [cleanup action](https://github.com/facebookincubator/TTPForge/blob/main/docs/foundations/cleanup.md#cleanup-basics).

--- a/docs/foundations/actions/edit_file.md
+++ b/docs/foundations/actions/edit_file.md
@@ -60,6 +60,10 @@ You can specify the following YAML fields for the `edit_file` action:
     and replace all matches thereof. Must always be paired with `new:`
   - `new:` (type: `string`) string with which to replace the string/pattern
     specified by `old:` - must always be paired with `old:`
+- `cleanup:` you can set this to `default` in order to automatically restore the
+  original file once the TTP completes. **Note**: this only works when
+  `backup_file` is set. You can also define a custom
+  [cleanup action](https://github.com/facebookincubator/TTPForge/blob/main/docs/foundations/cleanup.md#cleanup-basics).
 
 ## Notes
 

--- a/docs/foundations/cleanup.md
+++ b/docs/foundations/cleanup.md
@@ -74,11 +74,12 @@ provides two useful command line flags for the `ttpforge run` command:
 
 ## Default Cleanup Actions
 
-Certain action types, such as [create_file](actions/create_file.md) have a
-default cleanup action that can be invoked by specifying `cleanup: default` in
-their YAML configuration. In the case of `create_file`, the default cleanup
-action removes the created file. Check out the example below, which you can run
-with `ttpforge run examples//cleanup/default.yaml`:
+Certain action types (such as [create_file](actions/create_file.md) and
+[edit_file](actions/create_file.md)) have a default cleanup action that can be
+invoked by specifying `cleanup: default` in their YAML configuration. In the
+case of `create_file`, the default cleanup action removes the created file.
+Check out the example below, which you can run with
+`ttpforge run examples//cleanup/default.yaml`:
 
 https://github.com/facebookincubator/TTPForge/blob/246f1a2b6b57714a56c5ac3f321399d49243a4eb/example-ttps/cleanup/default.yaml#L1-L12
 


### PR DESCRIPTION
Summary: Update documentation to reference new `edit_file` default cleanup functionality added by d0n601 and fix a couple typos

Differential Revision: D51589311


