### PR TITLE
💡 [REQUEST] - Update documentation for `copy_path` action

### DIFF
--- a/docs/foundations/actions.md
+++ b/docs/foundations/actions.md
@@ -4,6 +4,7 @@ TTPForge supports the following types of actions:
 
 - [inline:](actions/inline.md) Run Shell Commands
 - [create_file:](actions/create_file.md) Create Files on Disk
+- [copy_path:](actions/copy_path.md) Copy File or Directory on Disk
 - [edit_file:](actions/edit_file.md) Append/Delete/Replace Lines in Files
 - [remove_path:](actions/remove_path.md) Delete Files/Directories
 - [print_str:](actions/print_str.md) Print Strings to the Screen

--- a/docs/foundations/actions/copy_path.md
+++ b/docs/foundations/actions/copy_path.md
@@ -1,0 +1,54 @@
+# TTPForge Actions: `copy_path`
+
+The `copy_path` action can be used to copy files on disk without the need to
+loudly invoke a shell and use `cat`, `echo`, or `cp`. Check out the TTP below to
+see how it works:
+
+```yaml
+---
+name: copy_path_example
+description: |
+  This TTP shows you how to use the copy_path action type
+  to copy a file on disk.
+requirements:
+  platforms:
+    - os: darwin
+    - os: linux
+steps:
+  - name: copy-passwd-file
+    copy_path: /etc/passwd
+    to: /tmp/ttpforge_copy_{{randAlphaNum 10}}
+    mode: 0600
+    cleanup: default
+```
+
+You can experiment with the above TTP by installing the `examples` TTP
+repository (skip this if `ttpforge list repos` shows that the `examples` repo is
+already installed):
+
+```bash
+ttpforge install repo https://github.com/facebookincubator/TTPForge --name examples
+```
+
+and then running the below command:
+
+```bash
+ttpforge run examples//actions/copy-path/basic.yaml
+```
+
+## Fields
+
+You can specify the following YAML fields for the `copy_path:` action:
+
+- `copy_path:` (type: `string`) the path to the file or directory you want to
+  copy.
+- `to:` (type: `string`) the path to the file or directory you want to write the
+  copy to file.
+- `recursive:` (type: `bool`) whether or not the copy action should be recursive
+  (copy all files in directory)
+- `overwrite:` (type: `bool`) whether the file(s) should be overwritten if they
+  already exist in the destination.
+- `mode:` the octal permission mode (`chmod` style) for the new file.
+- `cleanup:` you can set this to `default` in order to automatically cleanup the
+  created file, or define a custom
+  [cleanup action](https://github.com/facebookincubator/TTPForge/blob/main/docs/foundations/cleanup.md#cleanup-basics).

--- a/example-ttps/actions/copy-path/basic.yaml
+++ b/example-ttps/actions/copy-path/basic.yaml
@@ -1,0 +1,18 @@
+---
+tests:
+  - name: default
+
+name: copy_path_example
+description: |
+  This TTP shows you how to use the copy_path action type
+  to copy a file on disk.
+requirements:
+  platforms:
+    - os: darwin
+    - os: linux
+steps:
+  - name: copy-passwd-file
+    copy_path: /etc/passwd
+    to: /tmp/ttpforge_copy_{{randAlphaNum 10}}
+    mode: 0600
+    cleanup: default


### PR DESCRIPTION
Summary:
Added `copy_path` usage and example to documentation.

* Add an example TTP to `/example-ttps/actions/copy_path/basic.yaml`.

* Add markdown documentation that references the example to `/docs/foundations/actions/copy_path.md`.

* Add a link to your `copy_path` docs in `/docs/foundations/actions.md`.

Reviewed By: d3sch41n

Differential Revision: D51827325


