### PR TITLE
Fix GitHub embed link to `copy_path` action example documentation.

### DIFF
--- a/docs/foundations/actions/copy_path.md
+++ b/docs/foundations/actions/copy_path.md
@@ -4,23 +4,7 @@ The `copy_path` action can be used to copy files on disk without the need to
 loudly invoke a shell and use `cat`, `echo`, or `cp`. Check out the TTP below to
 see how it works:
 
-```yaml
----
-name: copy_path_example
-description: |
-  This TTP shows you how to use the copy_path action type
-  to copy a file on disk.
-requirements:
-  platforms:
-    - os: darwin
-    - os: linux
-steps:
-  - name: copy-passwd-file
-    copy_path: /etc/passwd
-    to: /tmp/ttpforge_copy_{{randAlphaNum 10}}
-    mode: 0600
-    cleanup: default
-```
+https://github.com/facebookincubator/TTPForge/blob/ce5561457f6d9a6f61cf3b6ed0b3ea69a32550eb/example-ttps/actions/copy-path/basic.yaml#L1-L18
 
 You can experiment with the above TTP by installing the `examples` TTP
 repository (skip this if `ttpforge list repos` shows that the `examples` repo is

--- a/example-ttps/actions/copy-path/basic.yaml
+++ b/example-ttps/actions/copy-path/basic.yaml
@@ -1,7 +1,4 @@
 ---
-tests:
-  - name: default
-
 name: copy_path_example
 description: |
   This TTP shows you how to use the copy_path action type
@@ -10,6 +7,8 @@ requirements:
   platforms:
     - os: darwin
     - os: linux
+tests:
+  - name: default
 steps:
   - name: copy-passwd-file
     copy_path: /etc/passwd


### PR DESCRIPTION
Summary: Follow up to D51827325, which updated the documentation to include the copy_path action and examples. This diff updates the example yaml to use GitHub snippets as opposed to hard coded yaml.

Reviewed By: d3sch41n

Differential Revision: D51872385


