### PR TITLE
TTP Testing: Add Default Dry-Run Test Case

### DIFF
--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -23,4 +23,4 @@ ttpforge_binary=$(realpath "${ttpforge_binary}")
   --arg run_second_step=true
 
 # run all the TTP test cases
-./run-all-ttp-tests.sh "${ttpforge_binary}"
+./run-all-ttp-tests.sh "${ttpforge_binary}" "example-ttps"

--- a/pkg/blocks/preamble.go
+++ b/pkg/blocks/preamble.go
@@ -1,0 +1,59 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package blocks
+
+import (
+	"fmt"
+
+	"github.com/facebookincubator/ttpforge/pkg/args"
+)
+
+// PreambleFields are TTP fields that can be parsed
+// prior to rendering the TTP steps with `text/template`
+//
+// **Attributes:**
+//
+// Name: The name of the TTP.
+// Description: A description of the TTP.
+// MitreAttackMapping: A MitreAttack object containing mappings to the MITRE ATT&CK framework.
+// Requirements: The Requirements to run the TTP
+// ArgSpecs: An slice of argument specifications for the TTP.
+type PreambleFields struct {
+	Name               string              `yaml:"name,omitempty"`
+	Description        string              `yaml:"description"`
+	MitreAttackMapping *MitreAttack        `yaml:"mitre,omitempty"`
+	Requirements       *RequirementsConfig `yaml:"requirements,omitempty"`
+	ArgSpecs           []args.Spec         `yaml:"args,omitempty,flow"`
+}
+
+// Validate validates the preamble fields.
+// It is used by both `ttpforge run` and `ttpforge test`
+func (pf *PreambleFields) Validate() error {
+	// validate MITRE mapping
+	if pf.MitreAttackMapping != nil && len(pf.MitreAttackMapping.Tactics) == 0 {
+		return fmt.Errorf("TTP '%s' has a MitreAttackMapping but no Tactic is defined", pf.Name)
+	}
+
+	// validate requirements
+	if err := pf.Requirements.Validate(); err != nil {
+		return fmt.Errorf("TTP '%s' has an invalid requirements section: %w", pf.Name, err)
+	}
+	return nil
+}

--- a/run-all-ttp-tests.sh
+++ b/run-all-ttp-tests.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 set -e
 
-cd "$(dirname "$0")"
-"$1" test example-ttps/**/*.yaml
+# validate first argument
+TTPFORGE_BINARY="$1"
+if [ ! -f "${TTPFORGE_BINARY}" ]
+then
+  echo "Invalid TTPForge Binary Path Specified!"
+  exit 1
+fi
+TTPFORGE_BINARY=$(realpath "${TTPFORGE_BINARY}")
+
+# validate second argument
+TTP_DIR="$2"
+if [ ! -d "${TTP_DIR}" ]
+then
+  echo "Invalid TTP Directory Specified!"
+  exit 1
+fi
+TTP_DIR=$(realpath "${TTP_DIR}")
+
+TTP_FILE_LIST="$(find "${TTP_DIR}" -name "*.yaml")"
+for TTP_FILE in ${TTP_FILE_LIST}
+do
+    ${TTPFORGE_BINARY} test "${TTP_FILE}"
+done


### PR DESCRIPTION
Summary:
* Buck will now validate all TTP schema fields (requirements, arguments, metadata, etc) for TTPForge and ForgeArmory. It will validate `steps:` where possible, though explicit test case definition is required in some cases
* Buck will also run all integration tests defined with the TTP `tests:` feature for both TTPForge and ForgeArmory 
* TTPForge will auto-generate a dry-run test case for every TTP that does not need arguments specified. 
* This replaces the  schema validation prototype previously implemented in ForgeArmory, as with the `--dry-run` flag that I implemented previously we now can validate directly against the TTPForge source-of-truth schema without any need for synchronization to an external schema.

Differential Revision: D51896839


