### PR TITLE
Add Remove Path To Action Candidates

### DIFF
--- a/pkg/blocks/removepath.go
+++ b/pkg/blocks/removepath.go
@@ -38,6 +38,11 @@ type RemovePathAction struct {
 	FileSystem     afero.Fs `yaml:"-,omitempty"`
 }
 
+// NewRemovePathAction creates a new RemovePathAction.
+func NewRemovePathAction() *RemovePathAction {
+	return &RemovePathAction{}
+}
+
 // IsNil checks if the step is nil or empty and returns a boolean value.
 func (s *RemovePathAction) IsNil() bool {
 	switch {

--- a/pkg/blocks/step.go
+++ b/pkg/blocks/step.go
@@ -190,8 +190,7 @@ func (s *Step) Validate(execCtx TTPExecutionContext) error {
 // ParseAction decodes an action (from step or cleanup) in YAML
 // format into the appropriate struct
 func (s *Step) ParseAction(node *yaml.Node) (Action, error) {
-	// actionCandidates := []Action{NewBasicStep(), NewFileStep(), NewEditStep(), NewFetchURIStep(), NewCreateFileStep()}
-	actionCandidates := []Action{NewBasicStep(), NewFileStep(), NewSubTTPStep(), NewEditStep(), NewFetchURIStep(), NewCreateFileStep(), NewCopyPathStep(), &PrintStrAction{}}
+	actionCandidates := []Action{NewBasicStep(), NewFileStep(), NewSubTTPStep(), NewEditStep(), NewFetchURIStep(), NewCreateFileStep(), NewCopyPathStep(), NewRemovePathAction(), &PrintStrAction{}}
 	var action Action
 	for _, actionType := range actionCandidates {
 		err := node.Decode(actionType)


### PR DESCRIPTION
Summary:
The `remove_path` action was usable as [documented](https://github.com/facebookincubator/TTPForge/blob/d912078663d1807615e1b7efe5d03ddd5a9ea596/docs/foundations/actions/remove_path.md).

This change includes the `remove_path` step inside of the `ParseAction` function in order to make it callable via YAML templates as stated in the documentation.

Reviewed By: d3sch41n

Differential Revision: D52525186


