### PR TITLE
Example of path_exists Post-Execution Check

### DIFF
--- a/example-ttps/checks/path-exists.yaml
+++ b/example-ttps/checks/path-exists.yaml
@@ -1,0 +1,24 @@
+---
+name: Demo of the path_exists Post-Execution Check
+description: |
+  The `path_exists` check can be used to verify that a given
+  file exists and has the correct hash. This helps
+  TTP authors ensure that their TTP executed correctly and wasn't
+  blocked by EDR/AV.
+requirements:
+  platforms:
+    - os: darwin
+    - os: linux
+tests:
+  - name: default
+steps:
+  - name: create_demo_file
+    create_file: |-
+      {{$target_path := (printf "/tmp/ttpforge-path-exists-demo-%v" (randAlphaNum 10))}}{{$target_path}}
+    contents: foo
+    cleanup: default
+    checks:
+      - msg: "Expected path does not exist or does not have correct contents!"
+        path_exists: "{{$target_path}}"
+        checksum:
+          sha256: 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae


### PR DESCRIPTION
Summary:
Handling a quick request that I didn't have time for before heading out, I hate loose ends

* Example TTP utilizing the path_exists post-execution check
* Documentation to follow that will render this YAML as a github code snippet once it lands

Differential Revision: D52914073


