### PR TITLE
Remove Args from TTPExecutionConfig

### DIFF
--- a/pkg/blocks/basicstep_test.go
+++ b/pkg/blocks/basicstep_test.go
@@ -84,16 +84,10 @@ outputs:
     filters:
     - json_path: foo.bar`
 	var s BasicStep
-	execCtx := TTPExecutionContext{
-		Cfg: TTPExecutionConfig{
-			Args: map[string]any{
-				"myarg": "baz",
-			},
-		},
-	}
+	var execCtx TTPExecutionContext
 	err := yaml.Unmarshal([]byte(content), &s)
 	require.NoError(t, err)
-	err = s.Validate(execCtx)
+	err = s.Validate(TTPExecutionContext{})
 	require.NoError(t, err)
 
 	// execute and check result

--- a/pkg/blocks/context.go
+++ b/pkg/blocks/context.go
@@ -36,7 +36,6 @@ type TTPExecutionConfig struct {
 	DryRun              bool
 	NoCleanup           bool
 	CleanupDelaySeconds uint
-	Args                map[string]any
 	Repo                repos.Repo
 	Stdout              io.Writer
 	Stderr              io.Writer

--- a/pkg/blocks/context_test.go
+++ b/pkg/blocks/context_test.go
@@ -51,12 +51,6 @@ func TestExpandVariablesStepResults(t *testing.T) {
 	stepResults.ByIndex = append(stepResults.ByIndex, stepResults.ByName["second_step"])
 	stepResults.ByIndex = append(stepResults.ByIndex, stepResults.ByName["third_step"])
 	execCtx := TTPExecutionContext{
-		Cfg: TTPExecutionConfig{
-			Args: map[string]any{
-				"arg1": "myarg1",
-				"arg2": "myarg2",
-			},
-		},
 		StepResults: stepResults,
 	}
 

--- a/pkg/blocks/fetchuri_test.go
+++ b/pkg/blocks/fetchuri_test.go
@@ -181,12 +181,7 @@ steps:
 			err := yaml.Unmarshal([]byte(tc.content), &ttps)
 			assert.NoError(t, err)
 
-			execCtx := TTPExecutionContext{
-				Cfg: TTPExecutionConfig{
-					Args: map[string]any{},
-				},
-			}
-
+			var execCtx TTPExecutionContext
 			err = ttps.Validate(execCtx)
 			if tc.wantError {
 				assert.Error(t, err)
@@ -207,11 +202,7 @@ location: /tmp/test.html
 overwrite: true
 `
 	var s FetchURIStep
-	execCtx := TTPExecutionContext{
-		Cfg: TTPExecutionConfig{
-			Args: map[string]any{},
-		},
-	}
+	var execCtx TTPExecutionContext
 	err := yaml.Unmarshal([]byte(content), &s)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Summary:
ryanstewart helpfully flagged a lot of tech debt for my attention - the entire use of Args in the TTPExecutionConfig structure was a holdover from the days before we used native golang templates. Since all arg expansion is performed at load time, we do not need to include the argument values in the runtime TTPExecutionContext 

This will simplify questions currently under discussion about how to handle TTPExecutionContext properly for SubTTPs

Differential Revision: D54087784


