### PR TITLE
Capture signals in steps execution and perform cleanups before exit

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,7 +64,15 @@ func buildRunCommand(cfg *Config) *cobra.Command {
 				return nil
 			}
 
-			if _, err := ttp.Execute(execCtx); err != nil {
+			runErr := ttp.Execute(*execCtx)
+			// Run clean up always
+			cleanupErr := ttp.RunCleanup(*execCtx)
+
+			if cleanupErr != nil {
+				logging.L().Warnf("Failed to run cleanup: %v", cleanupErr)
+			}
+
+			if runErr != nil {
 				return fmt.Errorf("failed to run TTP at %v: %v", ttpAbsPath, err)
 			}
 			return nil

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -58,7 +58,6 @@ func checkRunCmdTestCase(t *testing.T, tc runCmdTestCase) {
 	}
 	require.NoError(t, err)
 	assert.Equal(t, tc.expectedStdout, stdoutBuf.String())
-
 }
 
 func TestRun(t *testing.T) {
@@ -95,7 +94,7 @@ func TestRun(t *testing.T) {
 		},
 		{
 			name:        "subttp-cleanup",
-			description: "verify that execution of a subTTP with cleanup succeeds",
+			description: "when one of subTTP causes failures then cleanups executed in right order",
 			args: []string{
 				"-c",
 				testConfigFilePath,

--- a/pkg/blocks/basicstep_test.go
+++ b/pkg/blocks/basicstep_test.go
@@ -84,10 +84,10 @@ outputs:
     filters:
     - json_path: foo.bar`
 	var s BasicStep
-	var execCtx TTPExecutionContext
+	execCtx := NewTTPExecutionContext()
 	err := yaml.Unmarshal([]byte(content), &s)
 	require.NoError(t, err)
-	err = s.Validate(TTPExecutionContext{})
+	err = s.Validate(execCtx)
 	require.NoError(t, err)
 
 	// execute and check result

--- a/pkg/blocks/context.go
+++ b/pkg/blocks/context.go
@@ -43,9 +43,22 @@ type TTPExecutionConfig struct {
 
 // TTPExecutionContext - holds config and context for the currently executing TTP
 type TTPExecutionContext struct {
-	Cfg         TTPExecutionConfig
-	WorkDir     string
-	StepResults *StepResultsRecord
+	Cfg               TTPExecutionConfig
+	WorkDir           string
+	StepResults       *StepResultsRecord
+	actionResultsChan chan *ActResult
+	errorsChan        chan error
+	shutdownChan      chan bool
+}
+
+// NewTTPExecutionContext creates a new TTPExecutionContext with empty config and created channels
+func NewTTPExecutionContext() TTPExecutionContext {
+	return TTPExecutionContext{
+		StepResults:       NewStepResultsRecord(),
+		actionResultsChan: make(chan *ActResult, 1),
+		errorsChan:        make(chan error, 1),
+		shutdownChan:      SetupSignalHandler(),
+	}
 }
 
 // ExpandVariables takes a string containing the following types of variables

--- a/pkg/blocks/loader.go
+++ b/pkg/blocks/loader.go
@@ -149,16 +149,21 @@ func LoadTTP(ttpFilePath string, fsys afero.Fs, execCfg *TTPExecutionConfig, arg
 		}
 		ttp.WorkDir = wd
 	}
-	execCtx := &TTPExecutionContext{
-		Cfg:     *execCfg,
-		WorkDir: ttp.WorkDir,
+
+	execCtx := TTPExecutionContext{
+		Cfg:               *execCfg,
+		WorkDir:           ttp.WorkDir,
+		StepResults:       NewStepResultsRecord(),
+		actionResultsChan: make(chan *ActResult, 1),
+		errorsChan:        make(chan error, 1),
+		shutdownChan:      SetupSignalHandler(),
 	}
 
-	err = ttp.Validate(*execCtx)
+	err = ttp.Validate(execCtx)
 	if err != nil {
 		return nil, nil, err
 	}
-	return ttp, execCtx, nil
+	return ttp, &execCtx, nil
 }
 
 func readTTPBytes(ttpFilePath string, system afero.Fs) ([]byte, error) {

--- a/pkg/blocks/printstr.go
+++ b/pkg/blocks/printstr.go
@@ -32,6 +32,11 @@ type PrintStrAction struct {
 	Message        string `yaml:"print_str,omitempty"`
 }
 
+// NewPrintStrAction creates a new PrintStrAction.
+func NewPrintStrAction() *PrintStrAction {
+	return &PrintStrAction{}
+}
+
 // IsNil checks if the step is nil or empty and returns a boolean value.
 func (s *PrintStrAction) IsNil() bool {
 	switch {

--- a/pkg/blocks/requirements_test.go
+++ b/pkg/blocks/requirements_test.go
@@ -81,7 +81,7 @@ steps:
 			var ttp TTP
 			err := yaml.Unmarshal([]byte(tc.content), &ttp)
 			require.NoError(t, err)
-			var ctx TTPExecutionContext
+			ctx := NewTTPExecutionContext()
 			err = ttp.Validate(ctx)
 			if tc.expectValidateError {
 				require.Error(t, err)
@@ -89,7 +89,7 @@ steps:
 			}
 			require.NoError(t, err)
 
-			_, err = ttp.Execute(&ctx)
+			err = ttp.Execute(ctx)
 			if tc.expectExecuteError {
 				assert.Error(t, err)
 				return

--- a/pkg/blocks/step_test.go
+++ b/pkg/blocks/step_test.go
@@ -112,7 +112,7 @@ cleanup: default`,
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var s Step
-			var execCtx TTPExecutionContext
+			execCtx := NewTTPExecutionContext()
 
 			// parse the step
 			err := yaml.Unmarshal([]byte(tc.content), &s)
@@ -191,7 +191,7 @@ cleanup:
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var s Step
-			var execCtx TTPExecutionContext
+			execCtx := NewTTPExecutionContext()
 
 			// hack to get a valid temporary path without creating it
 			tmpFile, err := os.CreateTemp("", "ttpforge-test-cleanup-default")

--- a/pkg/blocks/subttp_test.go
+++ b/pkg/blocks/subttp_test.go
@@ -125,11 +125,11 @@ ttp: with/cleanup.yaml`,
 			repo, err := tc.spec.Load(tc.fsys, "")
 			require.NoError(t, err)
 
-			execCtx := TTPExecutionContext{
-				Cfg: TTPExecutionConfig{
-					Repo: repo,
-				},
+			execCtx := NewTTPExecutionContext()
+			execCtx.Cfg = TTPExecutionConfig{
+				Repo: repo,
 			}
+
 			err = step.Validate(execCtx)
 			require.NoError(t, err, "step failed to validate")
 

--- a/pkg/blocks/ttps_test.go
+++ b/pkg/blocks/ttps_test.go
@@ -329,18 +329,20 @@ steps:
 				return
 			}
 
+			execCtx := NewTTPExecutionContext()
 			// validate the TTP
-			err = ttp.Validate(TTPExecutionContext{})
+			err = ttp.Validate(execCtx)
 			require.NoError(t, err)
 
 			// run it
-			stepResults, err := ttp.Execute(&TTPExecutionContext{})
+			err = ttp.Execute(execCtx)
 			if tc.wantError {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 
+			stepResults := execCtx.StepResults
 			for index, output := range tc.expectedByIndexOut {
 				require.Equal(t, output, stepResults.ByIndex[index].Stdout)
 			}
@@ -391,7 +393,8 @@ mitre:
 			var ttp TTP
 			err := yaml.Unmarshal([]byte(tc.content), &ttp)
 			require.NoError(t, err)
-			err = ttp.Validate(TTPExecutionContext{})
+			execCtx := NewTTPExecutionContext()
+			err = ttp.Validate(execCtx)
 			if tc.wantError {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
Summary:
Here is my ~~first~~ new attempt to use channels to keep track of step results, errors or OS signals.

# Design overview
We could use channels to communicate results and errors produced from TTP steps executed.  Having this, we might also check additional channel to check if an OS signal was received.

This requires changes in the following parts:
0. Steps execution
0. Step results retrieving
0. Clean up execution for steps completed only
0. Sub-TTP processing
    0. Proper setup of execution context object per sub-ttp
    0. Postponing clean up execution till all steps of root  TTP are completed or an error encountered

Resolves https://github.com/facebookincubator/TTPForge/issues/476

Differential Revision: D54117726


