### PR TITLE
Add API Version and UUID to Example TTPs

### DIFF
--- a/example-ttps/actions/copy-path/basic.yaml
+++ b/example-ttps/actions/copy-path/basic.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 9f0ca08c-acd3-4dac-aeb9-41d07486d815
 name: copy_path_example
 description: |
   This TTP shows you how to use the copy_path action type

--- a/example-ttps/actions/create-file/basic.yaml
+++ b/example-ttps/actions/create-file/basic.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: df306aab-5824-4e32-bd04-76fb49da6b17
 name: create_file_basic
 description: |
   This TTP shows you how to use the create_file action type

--- a/example-ttps/actions/edit-file/append-delete.yaml
+++ b/example-ttps/actions/edit-file/append-delete.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 5e539ad7-1f78-4301-8c73-2794915fc05f
 name: edit_file_append_delete
 description: |
   Learn how to append and delete lines

--- a/example-ttps/actions/edit-file/replace.yaml
+++ b/example-ttps/actions/edit-file/replace.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: aac712b5-b5d4-4074-85ea-68a763172560
 name: edit_file_replace
 description: |
   This TTP shows you how to use the edit_file action type

--- a/example-ttps/actions/inline/basic.yaml
+++ b/example-ttps/actions/inline/basic.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 69f62d37-d68c-4a37-a3e2-871d1f292717
 name: inline_basic
 description: |
   This TTP shows you how to use the inline action type to

--- a/example-ttps/args/basic.yaml
+++ b/example-ttps/args/basic.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 2ae7c2ae-39be-4114-8618-306a62eedec2
 name: Basic Command-Line Arguments
 description: |
   TTPForge allows users to configure their TTPs' expected command-line

--- a/example-ttps/args/choices.yaml
+++ b/example-ttps/args/choices.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 8035624b-810f-4d03-9584-5331a6f311a7
 name: Explicitly Allowed Choices for Command-Line Arguments
 description: |
   Sometimes, you might need a TTP to only accept

--- a/example-ttps/args/regexp.yaml
+++ b/example-ttps/args/regexp.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: f3328ba0-45f9-4e9f-92c7-7d064a1a0e4a
 name: Regular Expression Validation for Command-Line Arguments
 description: |
   You can require user-provided command-line arguments

--- a/example-ttps/chaining/basic.yaml
+++ b/example-ttps/chaining/basic.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: d4f07331-8807-4725-a69b-e9b0ed2a8719
 name: Basic TTP Chaining
 description: |
   You can chain existing TTPs together to make larger

--- a/example-ttps/checks/path-exists.yaml
+++ b/example-ttps/checks/path-exists.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 7ba3a119-dde3-4900-97cb-9e105ca6e357
 name: Demo of the path_exists Post-Execution Check
 description: |
   The `path_exists` check can be used to verify that a given

--- a/example-ttps/cleanup/basic.yaml
+++ b/example-ttps/cleanup/basic.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: efb70470-4365-4be5-83e0-a009c0f2d49a
 name: Basic Cleanup Demonstration
 description: |
   Every time a step completes successfully, its cleanup action is enqueued.

--- a/example-ttps/cleanup/default.yaml
+++ b/example-ttps/cleanup/default.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 763a6408-d395-4737-92ba-4b8bb20b7976
 name: Default Cleanup Actions Demo
 description: |
   Certain types of actions, such as `create_file`, have a default cleanup

--- a/example-ttps/cleanup/failure.yaml
+++ b/example-ttps/cleanup/failure.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: cef0eb40-ec9e-421a-99e7-6bcb6aea1715
 name: Basic Cleanup Demonstration
 description: |
   If a step fails, we stop executing new steps, and begin

--- a/example-ttps/introduction/dotfile-backdoor-demo.yaml
+++ b/example-ttps/introduction/dotfile-backdoor-demo.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 4fdffbb9-714a-4489-b7c7-1af99d213681
 name: dotfile_backdoor
 description: |
   This TTP demonstrates the core features of TTPForge:

--- a/example-ttps/requirements/os-and-superuser.yaml
+++ b/example-ttps/requirements/os-and-superuser.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 60d10dc8-976d-42b7-9f75-f67f18daff64
 name: "Requirements Demo: OS and Superuser"
 description: |
   This TTP demonstrates the following features of the `requirements:` section:

--- a/example-ttps/templating/loops-integers.yaml
+++ b/example-ttps/templating/loops-integers.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: e2ea0015-ce87-4eb6-b895-a1d7e7764853
 name: Creating Loops with Templating - Integers Example
 description: |
   TTPForge's support for native Golang-style templates can

--- a/example-ttps/templating/loops-strings.yaml
+++ b/example-ttps/templating/loops-strings.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: e093f90f-1d0f-4162-8e9b-4ed3da5eb37e
 name: Creating Loops with Templating - Strings Example
 description: |
   This example demonstrates how to loop over specific

--- a/example-ttps/templating/loops.yaml
+++ b/example-ttps/templating/loops.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 97484c5d-e1ab-4162-8d55-ce53343b1a4c
 name: Creating Loops with Templating
 description: |
   TTPForge's support for native Golang-style templates can

--- a/example-ttps/tests/dry-run.yaml
+++ b/example-ttps/tests/dry-run.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 740e4d7f-02fb-442c-af38-8efb66334305
 name: Test Case with Dry Run
 description: |
   This TTP illustrates the impact of the `dry_run` field

--- a/example-ttps/tests/minimal-test-case.yaml
+++ b/example-ttps/tests/minimal-test-case.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: 4d928e89-eddc-4efa-8f02-2a87e53d8cc9
 name: Minimal Test Case Example for `tests:` Feature
 description: |
   This TTP illustrates the simplest possible valid test case

--- a/example-ttps/tests/with-args.yaml
+++ b/example-ttps/tests/with-args.yaml
@@ -1,4 +1,6 @@
 ---
+api_version: 2.0
+uuid: ec37ddc7-37f6-4311-a05e-e7f00ae41504
 name: Multiple Test Cases with Arguments
 description: |
   This TTP illustrates how to use the `tests` feature


### PR DESCRIPTION
Summary: Modified each file within `example-ttps` to include the new `api_version` and `uuid` tags.

Reviewed By: d3sch41n

Differential Revision: D54961591


