### PR TITLE
Validate UUIDs in YAML

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -108,7 +108,7 @@ func runTestsForTTP(ttpAbsPath string, timeoutSeconds int) error {
 
 	// validate as many fields as we can prior to actually
 	// invoking `ttpforge run`
-	if err := ttpf.PreambleFields.Validate(); err != nil {
+	if err := ttpf.PreambleFields.Validate(true); err != nil {
 		return fmt.Errorf("invalid TTP file %v: %w", ttpAbsPath, err)
 	}
 

--- a/pkg/blocks/preamble.go
+++ b/pkg/blocks/preamble.go
@@ -21,6 +21,7 @@ package blocks
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 
 	"github.com/facebookincubator/ttpforge/pkg/args"
 )
@@ -36,6 +37,8 @@ import (
 // Requirements: The Requirements to run the TTP
 // ArgSpecs: An slice of argument specifications for the TTP.
 type PreambleFields struct {
+	APIVersion         string              `yaml:"api_version,omitempty"`
+	UUID               string              `yaml:"uuid,omitempty"`
 	Name               string              `yaml:"name,omitempty"`
 	Description        string              `yaml:"description"`
 	MitreAttackMapping *MitreAttack        `yaml:"mitre,omitempty"`
@@ -45,7 +48,12 @@ type PreambleFields struct {
 
 // Validate validates the preamble fields.
 // It is used by both `ttpforge run` and `ttpforge test`
-func (pf *PreambleFields) Validate() error {
+func (pf *PreambleFields) Validate(strict bool) error {
+	if strict {
+		if _, err := uuid.Parse(pf.UUID); err != nil {
+			return fmt.Errorf("TTP '%s' has an invalid UUID", pf.Name)
+		}
+	}
 	// validate MITRE mapping
 	if pf.MitreAttackMapping != nil && len(pf.MitreAttackMapping.Tactics) == 0 {
 		return fmt.Errorf("TTP '%s' has a MitreAttackMapping but no Tactic is defined", pf.Name)

--- a/pkg/blocks/ttps.go
+++ b/pkg/blocks/ttps.go
@@ -115,7 +115,7 @@ func (t *TTP) Validate(execCtx TTPExecutionContext) error {
 	logging.L().Debugf("Validating TTP %q...", t.Name)
 
 	// Validate preamble fields
-	err := t.PreambleFields.Validate()
+	err := t.PreambleFields.Validate(false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Summary: Adding validation to check for UUIDs in TTP files if strict validation is specified.

Differential Revision: D54953656


