### PR TITLE
create ttp cmd not to fail if folder does not exists

### DIFF
--- a/cmd/createttp.go
+++ b/cmd/createttp.go
@@ -21,12 +21,13 @@ package cmd
 
 import (
 	"fmt"
-	"text/template"
-
 	"github.com/facebookincubator/ttpforge/pkg/platforms"
 	"github.com/google/uuid"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"os"
+	"path/filepath"
+	"text/template"
 )
 
 const ttpTemplate = `---
@@ -72,6 +73,12 @@ func buildCreateTTPCommand() *cobra.Command {
 			}
 			if exists {
 				return fmt.Errorf("%v already exists", newTTPFilePath)
+			}
+
+			// create the directory for the new TTP file, if it doesn't already exist
+			err = fsys.MkdirAll(filepath.Dir(newTTPFilePath), os.ModePerm)
+			if err != nil {
+				return fmt.Errorf("failed to create directory for new TTP file: %w", err)
 			}
 
 			// create the new TTP file with afero


### PR DESCRIPTION
Summary:
The create ttp cmd is failing if the folder where we want to create the new ttp does not exist:

```
./ttpforge create ttp ttps/nicola/my-ttp.yaml
WARN    No config file specified and default configuration file not found!
WARN    You probably want to run `ttpforge init`!
WARN    However, if you know what you are doing, then carry on :)
ERROR   failed to run command:
        failed to create new TTP file: open ttps/nicola/my-ttp.yaml: no such file or directory

```

This PR fixes the issue.

