### PR TITLE
Fix Flaky - TestFindFilePath

### DIFF
--- a/pkg/blocks/common_test.go
+++ b/pkg/blocks/common_test.go
@@ -104,7 +104,7 @@ func TestFindFilePath(t *testing.T) {
 	assert.NoError(t, err)
 
 	tempDir := filepath.Join(workdir, "temp_test_directory")
-	err = os.Mkdir(tempDir, 0755)
+	err = os.MkdirAll(tempDir, 0755)
 	assert.NoError(t, err)
 	defer os.RemoveAll(tempDir)
 


### PR DESCRIPTION
Summary:
The TestFindFilePath seems to have been failing for a long time, and has been disabled as a result.

From what I could tell the majority of the failures were caused by line 107 of `common_test.go`

Error:

```
mkdir /data/sandcastle/boxes/eden-trunk-hg-fbcode-fbsource/buck-out/v2/gen/fbcode/fec7e7876e628ce7/security/redteam/purple_team/ttpforge/pkg/blocks/__blocks_test__/temp_test_directory: file exists
```
https://www.internalfb.com/intern/testinfra/diagnostics/15762598732684907.281475092932540.1717744299/
https://www.internalfb.com/intern/testinfra/diagnostics/15762598732684907.281475092932540.1717744298/
etc...

Modifying `os.Mkdir` to `os.MkdirAll` should prevent an error from being thrown in the event that this directory already exists on the system.

Differential Revision: D58301576
