### PR TITLE
Remove External Dependency From GitHub README Installation Steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,9 @@ to learn more!
 1. Get latest TTPForge release:
 
    ```bash
-   bashutils_url="https://raw.githubusercontent.com/l50/dotfiles/main/bashutils"
-
-   bashutils_path="/tmp/bashutils"
-
-   if [[ ! -f "${bashutils_path}" ]]; then
-      curl -s "${bashutils_url}" -o "${bashutils_path}"
-   fi
-
-   source "${bashutils_path}"
-
-   fetchFromGithub "facebookincubator" "TTPForge" "latest" ttpforge
+   curl \
+   https://raw.githubusercontent.com/facebookincubator/TTPForge/main/dl-rl.sh \
+   | bash
    ```
 
    At this point, the latest `ttpforge` release should be in

--- a/dl-rl.sh
+++ b/dl-rl.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+set -euo pipefail
+
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+ASSETS=$(curl -s "https://api.github.com/repos/facebookincubator/TTPForge/releases/latest" | awk -F '"' '/browser_download_url/{print $4}')
+
+if [[ "$ARCH" == "x86_64" ]]; then ARCH="amd64"; fi
+if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then ARCH="arm64"; fi
+
+for ASSET in $ASSETS
+do
+    if [[ $ASSET == *"$OS"* && $ASSET == *"$ARCH"* ]]; then
+        curl -sLo "/tmp/$(basename "$ASSET")" "$ASSET"
+        echo "Download of TTPForge latest release from GitHub is complete."
+        mkdir -p "$HOME/.local/bin"
+        tar xf "/tmp/$(basename "$ASSET")" ttpforge
+        cp ttpforge "$HOME/.local/bin/ttpforge"
+        rm "/tmp/$(basename "$ASSET")"
+        echo "Copied ttpforge to $HOME/.local/bin/ as ttpforge"
+        exit
+    fi
+done


### PR DESCRIPTION
Summary: The installation steps in the README contained a reference to a file from another repository. I've created `dl-gh-releases.sh` within this repository that contains the necessary functionality to download the latest GitHub release binaries.

Reviewed By: d3sch41n

Differential Revision: D62530409
