### PR TITLE
Add Default Cleanup Action to `fetch_uri` and examples TTPs

### DIFF
--- a/example-ttps/actions/fetchuri/basic.yaml
+++ b/example-ttps/actions/fetchuri/basic.yaml
@@ -1,0 +1,11 @@
+---
+api_version: 2.0
+uuid: fe7f257f-19d2-4324-8590-bfddeb1156e2
+name: fetch_uri_basic_example
+description: |
+  This TTP shows you how to use the fetch action type fetch files with an http request.
+steps:
+  - name: Fetch Something
+    fetch_uri: https://raw.githubusercontent.com/facebookincubator/TTPForge/refs/heads/main/README.md
+    location: /tmp/ttpforge_fetch_uri_file_{{randAlphaNum 10}}
+    cleanup: default

--- a/example-ttps/actions/fetchuri/proxy.yaml
+++ b/example-ttps/actions/fetchuri/proxy.yaml
@@ -1,0 +1,12 @@
+---
+api_version: 2.0
+uuid: 81af6d8f-0da9-49cd-8fff-8edd4adc7bfe
+name: fetch_uri_proxy_example
+description: |
+  This TTP shows you how to use the fetch action type fetch files with an http request through an http proxy.
+steps:
+  - name: Fetch Something Through Proxy
+    fetch_uri: https://raw.githubusercontent.com/facebookincubator/TTPForge/refs/heads/main/README.md
+    location: /tmp/ttpforge_fetch_uri_file_{{randAlphaNum 10}}
+    proxy: http://localhost:8080
+    cleanup: default

--- a/pkg/blocks/fetchuri.go
+++ b/pkg/blocks/fetchuri.go
@@ -108,22 +108,15 @@ func (f *FetchURIStep) Validate(execCtx TTPExecutionContext) error {
 // Execute runs the step and returns an error if one occurs.
 func (f *FetchURIStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 	logging.L().Info("========= Executing ==========")
-
+	logging.L().Infof("FetchURI: %s", f.FetchURI)
 	if err := f.fetchURI(execCtx); err != nil {
 		logging.L().Error(zap.Error(err))
 		return nil, err
 	}
 
 	logging.L().Info("========= Result ==========")
-
+	logging.L().Infof("Fetched URI to location: %s", f.Location)
 	return &ActResult{}, nil
-}
-
-// Cleanup is a method to establish a link with the Cleanup interface.
-// Assumes that the type is the cleanup step and is invoked by
-// f.CleanupStep.Cleanup.
-func (f *FetchURIStep) Cleanup(execCtx TTPExecutionContext) (*ActResult, error) {
-	return f.Execute(execCtx)
 }
 
 // fetchURI executes the FetchURIStep with the specified Location, Uri, and additional arguments,
@@ -180,4 +173,12 @@ func (f *FetchURIStep) fetchURI(execCtx TTPExecutionContext) error {
 	logging.L().Debugw("wrote contents of URI to specified location", "location", absLocal, "uri", f.FetchURI)
 
 	return nil
+}
+
+// GetDefaultCleanupAction will instruct the calling code
+// to remove the file fetched by this action.
+func (s *FetchURIStep) GetDefaultCleanupAction() Action {
+	return &RemovePathAction{
+		Path: s.Location,
+	}
 }


### PR DESCRIPTION
Summary:
Used `remove_path` action to implement default cleanup action for `fetch_uri` that removes the downloaded file.

Also added `basic.yaml` and `proxy.yaml` examples under `example-ttps/actions/fetchuri`.

Differential Revision: D69863376


