### PR TITLE
Add `expect` action documentation.

### DIFF
--- a/docs/foundations/actions.md
+++ b/docs/foundations/actions.md
@@ -6,8 +6,10 @@ TTPForge supports the following types of actions:
 - [create_file:](actions/create_file.md) Create Files on Disk
 - [copy_path:](actions/copy_path.md) Copy File or Directory on Disk
 - [edit_file:](actions/edit_file.md) Append/Delete/Replace Lines in Files
+- [expect:](actions/expect.md) Automate Interactive Command Executions via
+  Expect.
 - [remove_path:](actions/remove_path.md) Delete Files/Directories
-- [fetch_uri:](actions/fetch_uri.md) Downloads a File from URL to Disk.
+- [fetch_uri:](actions/fetch_uri.md) Downloads a File from URL to Disk
 - [print_str:](actions/print_str.md) Print Strings to the Screen
 - [file:](actions/file.md) Execute an External Program (No Shell)
 - [ttp:](chaining.md) Chain Multiple TTPForge TTPs together

--- a/docs/foundations/actions/expect.md
+++ b/docs/foundations/actions/expect.md
@@ -1,0 +1,50 @@
+# TTPForge Actions: `expect`
+
+The `expect` action is designed to automate interactions with command-line
+programs that require user input. By scripting responses to prompts, `expect`
+allows you to execute commands that would otherwise pause for manual input,
+making it ideal for automating tasks in interactive environments. This action
+leverages the go-expect library to handle the automation of these interactions.
+
+## Automating Interactive Scripts
+
+This example demonstrates how to use the `expect` action to automate interaction
+with an interactive Python script:
+https://github.com/facebookincubator/TTPForge/blob/ffe3d206d747c27d1043cd0a10517831568ee364/example-ttps/actions/expect/expect.yaml#L1C1-L30C29
+
+You can experiment with the above TTP by installing the `examples` TTP
+repository (skip this if `ttpforge list repos` shows that the `examples` repo is
+already installed):
+
+```bash
+ttpforge install repo https://github.com/facebookincubator/TTPForge --name examples
+```
+
+and then running the below command:
+
+```bash
+ttpforge run examples//actions/expect/expect.yaml
+```
+
+## Fields
+
+You can specify the following YAML fields for the `expect` action:
+
+- `expect:` (type: `string`) the command to execute that requires interaction.
+- `responses:` (type: `list`) a list of responses to provide. Each entry can
+  contain the following fields:
+  - `prompt:` (type: `string`) the text prompt to expect from the command.
+  - `response:` (type: `string`) the response to provide when the prompt is
+    encountered.
+- `cleanup:` Define a custom
+  [cleanup action](https://github.com/facebookincubator/TTPForge/blob/main/docs/foundations/cleanup.md#cleanup-basics)
+  to execute after the expect action completes..
+
+## Notes
+
+- The `expect` action is particularly useful for automating tasks that involve
+  interactive command-line tools, ensuring that your TTPs can run unattended.
+- Ensure that the prompts specified in `responses` match exactly with the output
+  of the command to ensure correct automation.
+- The `expect` action can be used in combination with other actions to create
+  complex, automated workflows.


### PR DESCRIPTION
Summary: Added `expect` step to the  `docs/actions` section.

Differential Revision: D70192169


