### PR TITLE
- Implement http_request action type

### DIFF
--- a/example-ttps/actions/http-request/get-parameters.yaml
+++ b/example-ttps/actions/http-request/get-parameters.yaml
@@ -1,0 +1,15 @@
+---
+api_version: 2.0
+uuid: b2d21ff8-92ea-4bf9-a21c-fc6bef0203d3
+name: http_request_with_parameters_example
+description: |
+  This TTP shows you how to use the http request action type to send a GET request to a url, with specified parameters.
+steps:
+  - name: make_request
+    http_request: https://exampleapi.com/facts/random
+    type: GET
+    parameters:
+      - name: "animal"
+        value: "cat"
+      - name: "amount"
+        value: "5"

--- a/example-ttps/actions/http-request/get.yaml
+++ b/example-ttps/actions/http-request/get.yaml
@@ -1,0 +1,20 @@
+---
+api_version: 2.0
+uuid: ce732c7f-13d3-1321-8590-bfeeeb11c6e2
+name: http_request_basic_example
+description: |
+  This TTP shows you how to use the http request action type to send a GET request to a url, with and without an http proxy.
+steps:
+  - name: Basic GET Request
+    http_request: https://facebook.com
+    type: GET
+    cleanup:
+      inline: |
+        echo "No cleanup required."
+  - name: Proxied GET Request
+    http_request: https://facebook.com
+    type: GET
+    proxy: http://localhost:8080
+    cleanup:
+      inline: |
+        echo "No cleanup required."

--- a/example-ttps/actions/http-request/post-full.yaml
+++ b/example-ttps/actions/http-request/post-full.yaml
@@ -1,0 +1,46 @@
+---
+api_version: 2.0
+uuid: af81ce65-70d2-496f-9aae-9086ce52bc4b
+name: http_request_post_example_full
+description: |
+  This TTP shows you how to use the http request action type to send a POST request containing
+  data, parsing the response with a regular expression and storing the result in an environmental
+  variable accessed in the next step.
+args:
+  - name: host
+    description: The target host for the requests to be made to.
+    default: api.example.com
+  - name: user_agent
+    description: The User-Agent header string to be sent with the requests.
+    default: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
+steps:
+  - name: POST Request With Regex
+    http_request: https://{{.Args.host}}/api/v1/config
+    type: POST
+    headers:
+      - field: User-Agent
+        value: {{.Args.user_agent}}
+      - field: Content-Type
+        value: application/x-www-form-urlencoded; charset=UTF-8
+      - field: Accepted-Encoding
+        value: gzip, deflate
+    body: >
+      params={
+        "client_input_params": {
+          "username_input": "",
+          "device_id": "android-3072a22f5cc5db69",
+        },
+        "example_params": {
+          "current_step": "LOGIN"
+        }
+      }
+      &bloks_versioning_id=6
+    regex: |
+      [^"]*arm
+    response: REQUEST_1_CONTEXT
+    cleanup:
+      inline: |
+        echo "No cleanup required."
+  - name: Do next
+    inline: |
+      echo $REQUEST_1_CONTEXT

--- a/pkg/blocks/httprequest.go
+++ b/pkg/blocks/httprequest.go
@@ -1,0 +1,232 @@
+/*
+Copyright © 2025-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package blocks
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/facebookincubator/ttpforge/pkg/logging"
+	"go.uber.org/zap"
+)
+
+// HTTPHeader represents a key-value pair for HTTP header.
+type HTTPHeader struct {
+	Field string `yaml:"field,omitempty"`
+	Value string `yaml:"value,omitempty"`
+}
+
+// HTTPParameter represents a single HTTP parameter.
+type HTTPParameter struct {
+	Name  string `yaml:"name,omitempty"`
+	Value string `yaml:"value,omitempty"`
+}
+
+// HTTPRequestStep represents a step in a process that consists of a main action,
+// a cleanup action, and additional metadata.
+type HTTPRequestStep struct {
+	actionDefaults `yaml:",inline"`
+	HTTPRequest    string           `yaml:"http_request,omitempty"`
+	Type           string           `yaml:"type,omitempty"`
+	Headers        []*HTTPHeader    `yaml:"headers,omitempty"`
+	Parameters     []*HTTPParameter `yaml:"parameters,omitempty"`
+	Body           string           `yaml:"body,omitempty"`
+	Regex          string           `yaml:"regex,omitempty"`
+	Proxy          string           `yaml:"proxy,omitempty"`
+	Response       string           `yaml:"response,omitempty"`
+}
+
+// NewHTTPRequestStep creates a new HTTPRequestStep instance and returns a pointer to it.
+func NewHTTPRequestStep() *HTTPRequestStep {
+	return &HTTPRequestStep{}
+}
+
+// IsNil checks if the step is nil or empty and returns a boolean value.
+func (r *HTTPRequestStep) IsNil() bool {
+	return r.HTTPRequest == ""
+}
+
+// Validate validates the HTTPRequestStep.
+func (r *HTTPRequestStep) Validate(execCtx TTPExecutionContext) error {
+
+	// Validate the target URL
+	if r.HTTPRequest != "" {
+		uri, err := url.Parse(r.HTTPRequest)
+		if err != nil {
+			return err
+		} else if uri.Host == "" || uri.Scheme == "" {
+			return fmt.Errorf("invalid URL given for request URL: %s", r.HTTPRequest)
+		}
+	}
+
+	// Validate the proxy URL
+	if r.Proxy != "" {
+		uri, err := url.Parse(r.Proxy)
+		if err != nil {
+			return err
+		} else if uri.Host == "" || uri.Scheme == "" {
+			return fmt.Errorf("invalid URL given for Proxy: %s", r.Proxy)
+		}
+	}
+
+	// Validate the http request type is valid
+	if r.Type != "" {
+		isHTTPMethod := false
+		for _, method := range []string{"GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"} {
+			if strings.EqualFold(r.Type, method) {
+				isHTTPMethod = true
+				break
+			}
+		}
+		if !isHTTPMethod {
+			return fmt.Errorf("unsupported HTTP request type: %s", r.Type)
+		}
+	}
+
+	// Validate headers
+	for _, header := range r.Headers {
+		if header.Field == "" || header.Value == "" {
+			return fmt.Errorf("broken HTTP header %s: %s", header.Value, header.Field)
+		}
+	}
+
+	// Validate parameters
+	for _, parameter := range r.Parameters {
+		if parameter.Name == "" || parameter.Value == "" {
+			return fmt.Errorf("broken HTTP parameters %s: %s", parameter.Name, parameter.Value)
+		}
+	}
+
+	// Validate regex
+	if r.Regex != "" {
+		regexTrim := strings.TrimSuffix(r.Regex, "\n")
+		_, err := regexp.Compile(regexTrim)
+		if err != nil {
+			return fmt.Errorf("invalid regular expression: %v", err)
+		}
+	}
+	return nil
+}
+
+// Execute runs the step and returns an error if one occurs.
+func (r *HTTPRequestStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
+	logging.L().Info("========= Executing ==========")
+	logging.L().Infof("HTTPRequest to: %s", r.HTTPRequest)
+	if err := r.SendRequest(execCtx); err != nil {
+		logging.L().Error(zap.Error(err))
+		return nil, err
+	}
+	logging.L().Info("========= Complete ==========")
+	return &ActResult{}, nil
+}
+
+// HTTPRequest executes the HTTPRequestStep.
+func (r *HTTPRequestStep) SendRequest(execCtx TTPExecutionContext) error {
+
+	// Gather the parameters
+	params := url.Values{}
+	for _, parameter := range r.Parameters {
+		params.Add(parameter.Name, parameter.Value)
+	}
+	// Construct the full URL with parameters
+	fullURL := fmt.Sprintf("%s?%s", r.HTTPRequest, params.Encode())
+
+	// Trim the body of any trailing new lines
+	trimBody := strings.TrimSuffix(r.Body, "\n")
+
+	// Create a new request with the specified method, URL, and body.
+	req, err := http.NewRequest(r.Type, fullURL, strings.NewReader(trimBody))
+	if err != nil {
+		return fmt.Errorf("Error creating request: %v", err)
+	}
+
+	// Loop through and set each header
+	for _, header := range r.Headers {
+		if header.Field != "" && header.Value != "" {
+			req.Header.Set(header.Field, header.Value)
+		}
+
+	}
+
+	// Send the request using the default HTTP client
+	client := &http.Client{}
+
+	// Set proxy if specified.
+	if r.Proxy != "" {
+		proxyURI, err := url.Parse(r.Proxy)
+		if err != nil {
+			return err
+		}
+		tr := &http.Transport{
+			Proxy: http.ProxyURL(proxyURI),
+		}
+		client = &http.Client{Transport: tr}
+	}
+
+	// Send the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("Error sending request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Error reading response body: %v", err)
+	}
+
+	// Build final response
+	finalResponse := string(body)
+
+	// If using regex to extract, part of the response.
+	if r.Regex != "" {
+		// Remove pesky new line from end of r.Regex input.
+		regexTrim := strings.TrimSuffix(r.Regex, "\n")
+		// Compile the regular expression.
+		re := regexp.MustCompile(regexTrim)
+
+		// Find all matches in the response body
+		matches := re.FindAllString(string(body), -1)
+		if matches != nil {
+			// If there are matches, use the first one as the final response.
+			finalResponse = matches[0]
+		} else {
+			finalResponse = "No matches for pattern found..."
+		}
+	}
+
+	// Store the response as an environment variable.
+	if r.Response != "" {
+		err = os.Setenv(r.Response, finalResponse)
+		if err != nil {
+			return fmt.Errorf("Error setting environment variable: %v", err)
+		}
+	}
+
+	logging.L().Infof("Response: %s", finalResponse)
+
+	return nil
+}

--- a/pkg/blocks/httprequest_test.go
+++ b/pkg/blocks/httprequest_test.go
@@ -1,0 +1,312 @@
+/*
+Copyright © 2025-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package blocks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestUnmarshalHTTPRequest(t *testing.T) {
+	testCases := []struct {
+		name      string
+		content   string
+		wantError bool
+	}{
+		{
+			name: "Simple http request",
+			content: `
+name: test basic
+description: this is a test basic test
+steps:
+  - name: get url
+    http_request: http://someuri.com
+`,
+			wantError: false,
+		},
+		{
+			name: "Request with specified type GET",
+			content: `
+name: test get
+description: This is a test with specified type
+steps:
+  - name: specific request type
+    http_request: http://someuri.com
+    type: GET
+`,
+			wantError: false,
+		},
+		{
+			name: "Request with proxy",
+			content: `
+name: test proxy
+description: This is a test with proxy
+steps:
+  - name: request through proxy
+    http_request: http://someuri.com
+    proxy: http://localhost:8080
+`,
+			wantError: false,
+		},
+		{
+			name: "Request with headers",
+			content: `
+name: test headers
+description: this is a test setting headers
+steps:
+  - name: request with headers
+    http_request: http://someuri.com
+    headers:
+      - field: "User-Agent"
+        value: "Mozilla/5.0 (platform; rv:gecko-version) Gecko/gecko-trail appname/appversion Mozilla/5.0 (platform; rv:gecko-version) Gecko/gecko-trail Firefox/firefox-version appname/appversion;"
+      - field: "Content-Type"
+        value: "application/x-www-form-urlencoded; charset=UTF-8"
+`,
+			wantError: false,
+		},
+		{
+			name: "Request with parameters",
+			content: `
+name: test parameters
+description: this is a test with http parameters
+steps:
+  - name: get with parameters
+    http_request: http://someuri.com
+    parameters:
+      - name: "foo"
+        value: "bar"
+      - name: "moo"
+        value: "cow"
+`,
+			wantError: false,
+		},
+		{
+			name: "POST Request with headers and body",
+			content: `
+name: test headers and body of POST request
+description: this is a test typical POST test
+steps:
+  - name: request with headers
+    http_request: http://someuri.com
+    type: POST
+    headers:
+      - field: "User-Agent"
+        value: "Mozilla/5.0 (platform; rv:gecko-version) Gecko/gecko-trail appname/appversion Mozilla/5.0 (platform; rv:gecko-version) Gecko/gecko-trail Firefox/firefox-version appname/appversion;"
+      - field: "Content-Type"
+        value: "application/x-www-form-urlencoded; charset=UTF-8"
+    body: "{'this': 'is', 'a': 'test', 'body': 'of', 'post': 'request'}"
+`,
+			wantError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var ttps TTP
+			err := yaml.Unmarshal([]byte(tc.content), &ttps)
+			if tc.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPequest(t *testing.T) {
+	testCases := []struct {
+		name      string
+		content   string
+		wantError bool
+	}{
+		{
+			name: "Simple http request",
+			content: `
+name: test basic
+description: this is a test basic test
+steps:
+  - name: get url
+    http_request: http://someuri.com
+`,
+			wantError: false,
+		},
+		{
+			name: "Request with specified type GET",
+			content: `
+name: test get
+description: This is a test with specified type
+steps:
+  - name: specific request type
+    http_request: http://someuri.com
+    type: GET
+`,
+			wantError: false,
+		},
+		{
+			name: "Request with proxy",
+			content: `
+name: test proxy
+description: This is a test with proxy
+steps:
+  - name: request through proxy
+    http_request: http://someuri.com
+    proxy: http://localhost:8080
+`,
+			wantError: false,
+		},
+		{
+			name: "Request with headers",
+			content: `
+name: test headers
+description: this is a test
+steps:
+  - name: request with headers
+    http_request: http://someuri.com
+    headers:
+      - field: "User-Agent"
+        value: "Mozilla/5.0 (platform; rv:gecko-version) Gecko/gecko-trail appname/appversion Mozilla/5.0 (platform; rv:gecko-version) Gecko/gecko-trail Firefox/firefox-version appname/appversion;"
+      - field: "Content-Type"
+        value: "application/x-www-form-urlencoded; charset=UTF-8"
+`,
+			wantError: false,
+		},
+		{
+			name: "Request with parameters",
+			content: `
+name: test parameters
+description: this is a test with http parameters
+steps:
+  - name: fetch file
+    http_request: http://someuri.com
+    parameters:
+      - name: "foo"
+        value: "bar"
+      - name: "moo"
+        value: "cow"
+`,
+			wantError: false,
+		},
+		{
+			name: "POST Request with headers and body",
+			content: `
+name: test headers and body of POST request
+description: this is a test typical POST test
+steps:
+  - name: request with headers
+    http_request: http://someuri.com
+    type: POST
+    headers:
+      - field: "User-Agent"
+        value: "Mozilla/5.0 (platform; rv:gecko-version) Gecko/gecko-trail appname/appversion Mozilla/5.0 (platform; rv:gecko-version) Gecko/gecko-trail Firefox/firefox-version appname/appversion;"
+      - field: "Content-Type"
+        value: "application/x-www-form-urlencoded; charset=UTF-8"
+    body: "{'this': 'is', 'a': 'test', 'body': 'of', 'post': 'request'}"
+`,
+			wantError: false,
+		},
+		{
+			name: "Invalid URL http request",
+			content: `
+name: test invalid url
+description: this is a test with an invalid url
+steps:
+  - name: get screwy url
+    http_request: somebrokenurl
+`,
+			wantError: true,
+		},
+		{
+			name: "Invalid Proxy URL request",
+			content: `
+name: test invalid proxy
+description: this is a test with an invalid proxy url
+steps:
+    - name: get url through bad proxy
+      http_request: https://someuri.com
+      proxy: thisnotaurlok
+`,
+			wantError: true,
+		},
+		{
+			name: "Malformed headers",
+			content: `
+name: malformed headers
+description: this is a test with headers missing value
+steps:
+  - name: get request with malformed headers
+    http_request: https://someuri.com
+    headers:
+      - field: "User-Agent"
+        value: "Mozilla/5.0 (platform; rv:gecko-version) Gecko/gecko-trail appname/appversion Mozilla/5.0 (platform; rv:gecko-version) Gecko/gecko-trail Firefox/firefox-version appname/appversion;"
+      - field: "Content-Type"
+`,
+			wantError: true,
+		},
+		{
+			name: "Malformed parameters",
+			content: `
+name: malformed parameters
+description: this is a test with parameter missing value
+steps:
+  - name: get url through bad proxy
+    http_request: https://someuri.com
+    parameters:
+      - name: "search"
+        value: "everything"
+      - name: "something_else"
+`,
+			wantError: true,
+		},
+		{
+			name: "Bad Regex",
+			content: `
+name: malformed regular expression
+description: this is a test with a weird regex pattern
+steps:
+  - name: get url through bad proxy
+    http_request: https://someuri.com
+    parameters:
+      - name: "search"
+        value: "everything"
+    regex: "(dfaefawefaew"
+`,
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var ttps TTP
+			err := yaml.Unmarshal([]byte(tc.content), &ttps)
+			assert.NoError(t, err)
+
+			execCtx := NewTTPExecutionContext()
+			err = ttps.Validate(execCtx)
+			if tc.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/blocks/step.go
+++ b/pkg/blocks/step.go
@@ -260,6 +260,7 @@ func (s *Step) ParseAction(node *yaml.Node) (Action, error) {
 		NewRemovePathAction(),
 		NewPrintStrAction(),
 		NewExpectStep(),
+		NewHTTPRequestStep(),
 	}
 
 	var action Action


### PR DESCRIPTION
Summary:
This adds a step/action type called `http_request` that  works like this:

GET request example:
```yaml
---
 http_request: https://facebook.com
    type: GET
    proxy: http://localhost:8080
    cleanup:
      inline: |
        echo "No cleanup required."
```


POST request example:
```yaml
    http_request: https://api.someexample.com/api/v1/someendoint/
    type: POST
    headers:
      - field: User-Agent
        value: {{.Args.user_agent}}
      - field: Content-Type
        value: application/x-www-form-urlencoded; charset=UTF-8
      - field: Accepted-Encoding
        value: gzip, deflate
    body: >
      params={
        "client_input_params": {
          "username_input": "",
        },
        "server_params": {
          "is_from_logged_out": 0,
          "device_id": "android-3072a22f5cc5db69",
          "waterfall_id": null,
          "event_source": "login_home_page",
        }
      }
      bloks_versioning_id=bda53c582346682c04dc1a0c2e6c3a8722128bacb46018428c2e82f7376c46f7
    regex: |
      [^"]*arm
    cleanup:
      inline: |
        echo "No cleanup required."
```



The fields have the following meaning:

```
http_request:
  `url`: URL to which the request is made.
  `type`: The http request type (GET, POST, PUT, PATCH, DELETE).
  `headers`: The http request headers, `field` and `value`.
  `parameters`: The http request parameters, `name` and `value`.
  `body`:  String for request body data.
  `proxy`: The http proxy to use for requests
  `regex`: Regular expression, if specified return only matching string.
  `response`: Shell variable name to store request's response.
```

Differential Revision: D69953549


