### PR TITLE
TTPForge: Add step level templating

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,7 +54,7 @@ func buildRunCommand(cfg *Config) *cobra.Command {
 			// based on the TTPs argument value specifications
 			ttpCfg.Repo = foundRepo
 
-			ttp, execCtx, err := blocks.LoadTTP(ttpAbsPath, foundRepo.GetFs(), &ttpCfg, argsList)
+			ttp, execCtx, err := blocks.LoadTTP(ttpAbsPath, foundRepo.GetFs(), &ttpCfg, map[string]string{}, argsList)
 			if err != nil {
 				return fmt.Errorf("could not load TTP at %v:\n\t%v", ttpAbsPath, err)
 			}

--- a/example-ttps/actions/http-request/output-to-variable.yaml
+++ b/example-ttps/actions/http-request/output-to-variable.yaml
@@ -1,0 +1,19 @@
+---
+api_version: 2.0
+uuid: 3f3dff0c-2a86-4f9f-89b0-d5c7a1c4aed6
+name: http_request_basic_example
+description: |
+  This TTP shows you how to use the http request action type to send a GET request to a url and store the response in a variable for
+  use in later steps.  Additionally, this TTP shows you how to use the regex action type to extract a portion of the response.
+steps:
+  - name: Basic GET Request
+    http_request: https://raw.githubusercontent.com/facebookincubator/TTPForge/refs/heads/main/README.md
+    type: GET
+    regex: "## Installation([^\n]*\n){10}"
+    outputvar: facebook_html
+    cleanup:
+      inline: |
+        echo "No cleanup required."
+  - name: Use variable
+    inline: |
+      echo 'The html returned from the GET request is: {[{.StepVars.facebook_html}]}'

--- a/example-ttps/actions/inline/output-to-variable.yaml
+++ b/example-ttps/actions/inline/output-to-variable.yaml
@@ -1,0 +1,19 @@
+---
+api_version: 2.0
+uuid: 69f62d37-d68c-4a37-a3e2-871d1f292717
+name: inline_basic
+description: |
+  This TTP shows you how to use the inline action type to
+  run basic shell commands and store the outputs in variables.
+steps:
+  - name: bash_output
+    inline: echo "This will be stored as a variable!"
+    outputvar: bash_output
+  - name: python_output
+    executor: python3
+    inline: |
+      msg = "This will also be stored as a variable!"
+      print(msg)
+    outputvar: python_output
+  - name: print_variables
+    print_str: "bash_output: {[{ .StepVars.bash_output }]}\npython_output: {[{ .StepVars.python_output }]}"

--- a/example-ttps/chaining/subttps-and-variables.yaml
+++ b/example-ttps/chaining/subttps-and-variables.yaml
@@ -1,0 +1,16 @@
+---
+api_version: 2.0
+uuid: d95a64f2-643e-4476-9efb-db2b1938d978
+name: Basic TTP Chaining
+description: |
+  SubTTps can set variables that can be used by other TTPs.  Variables set in SubTTps
+  are surfaced up to the parent TTP.
+tests:
+  - name: default
+steps:
+  - name: subttp_that_sets_variable
+    description: this step invokes another TTP, which sets the foo variable within its steps
+    ttp: //chaining/variables.yaml
+  - name: use_variable
+    description: this step uses a variable created in the previous subttp step
+    print_str: "Template this: {[{ .StepVars.foo }]}"

--- a/example-ttps/chaining/variables.yaml
+++ b/example-ttps/chaining/variables.yaml
@@ -1,0 +1,19 @@
+---
+api_version: 2.0
+uuid: 052e4cc0-b5eb-4680-859a-6756057fbab8
+name: TTP Variable Chaining
+description: |
+  This TTP demonstrates that you can output variables from some types of steps and use them
+  in other steps.  If a variable is already set, setting it again will overwrite the value.
+steps:
+  - name: create_variable
+    description: this step invokes a step that creates a variable
+    inline: "echo 'asdf'"
+    outputvar: foo
+  - name: overwrite_variable
+    description: this step overwrites the variable created in the previous step
+    inline: "echo 'qwerty'"
+    outputvar: foo
+  - name: use_variable
+    description: this step uses a variable created in the previous step
+    print_str: "Template this: {[{ .StepVars.foo }]}"

--- a/example-ttps/templating/sprig-helpers.yaml
+++ b/example-ttps/templating/sprig-helpers.yaml
@@ -1,0 +1,21 @@
+---
+api_version: 2.0
+uuid: 6e35795a-7d18-460b-935e-46d41cc593ef
+name: spring_helpers
+description: |
+  This TTP shows you how to use sprig helpers in your template injections.
+  You can use them with step variables too.
+args:
+  - name: word_to_b64_encode
+    description: The word to base64 encode
+    default: "Apple"
+steps:
+  - name: print_word
+    inline: echo "The word is {{ .Args.word_to_b64_encode }}"
+  - name: base64_encode_word
+    inline: echo "The b64 encoded word is {{ .Args.word_to_b64_encode | b64enc }}"
+  - name: base64_encode_word_to_variable
+    inline: echo "{{ .Args.word_to_b64_encode | b64enc }}"
+    outputvar: base64_encoded_word
+  - name: decode_word
+    print_str: "The b64 decoded word is {[{ .StepVars.base64_encoded_word | b64dec }]}"

--- a/pkg/blocks/actions.go
+++ b/pkg/blocks/actions.go
@@ -25,6 +25,7 @@ package blocks
 type Action interface {
 	IsNil() bool
 	Validate(execCtx TTPExecutionContext) error
+	Template(execCtx TTPExecutionContext) error
 	Execute(execCtx TTPExecutionContext) (*ActResult, error)
 	GetDescription() string
 	GetDefaultCleanupAction() Action
@@ -37,6 +38,7 @@ type Action interface {
 // Every new action type should embed this struct
 type actionDefaults struct {
 	Description string `yaml:"description,omitempty"`
+	OutputVar   string `yaml:"outputvar,omitempty"`
 }
 
 // IsNil provides a default implementation

--- a/pkg/blocks/basicstep.go
+++ b/pkg/blocks/basicstep.go
@@ -90,6 +90,16 @@ func (b *BasicStep) Validate(execCtx TTPExecutionContext) error {
 	return nil
 }
 
+// Template takes each applicable field in the step and replaces any template strings with their resolved values.
+func (b *BasicStep) Template(execCtx TTPExecutionContext) error {
+	var err error
+	b.Inline, err = execCtx.templateStep(b.Inline)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Execute runs the step and returns an error if one occurs.
 func (b *BasicStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultExecutionTimeout)
@@ -107,6 +117,10 @@ func (b *BasicStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 	result.Outputs, err = outputs.Parse(b.Outputs, result.Stdout)
 	if err != nil {
 		return nil, err
+	}
+	// Send stdout to the output variable
+	if b.OutputVar != "" {
+		execCtx.Vars.StepVars[b.OutputVar] = result.Stdout
 	}
 	return result, nil
 }

--- a/pkg/blocks/changedirectory.go
+++ b/pkg/blocks/changedirectory.go
@@ -66,6 +66,20 @@ func (step *ChangeDirectoryStep) Validate(_ TTPExecutionContext) error {
 	return nil
 }
 
+// Template takes each applicable field in the step and replaces any template strings with their resolved values.
+//
+// **Returns:**
+//
+// error: error if template resolution fails, nil otherwise
+func (step *ChangeDirectoryStep) Template(execCtx TTPExecutionContext) error {
+	var err error
+	step.Cd, err = execCtx.templateStep(step.Cd)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Execute runs the ChangeDirectoryStep, changing the current working directory and returns an error if any occur.
 //
 // **Returns:**

--- a/pkg/blocks/compositeaction.go
+++ b/pkg/blocks/compositeaction.go
@@ -40,6 +40,16 @@ func (ca *CompositeAction) Validate(execCtx TTPExecutionContext) error {
 	return nil
 }
 
+// Template each action in the composite action
+func (ca *CompositeAction) Template(execCtx TTPExecutionContext) error {
+	for _, a := range ca.actions {
+		if err := a.Template(execCtx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Execute runs the step and returns an error if one occurs.
 func (ca *CompositeAction) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 	for _, a := range ca.actions {

--- a/pkg/blocks/context.go
+++ b/pkg/blocks/context.go
@@ -20,16 +20,20 @@ THE SOFTWARE.
 package blocks
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"github.com/Masterminds/sprig/v3"
+	"github.com/facebookincubator/ttpforge/pkg/repos"
 	"io"
 	"regexp"
 	"strings"
-
-	"github.com/facebookincubator/ttpforge/pkg/repos"
+	"text/template"
 )
 
 const contextVariablePrefix = "$forge."
+const stepTemplateLeftDelim = "{[{"
+const stepTemplateRightDelim = "}]}"
 
 // TTPExecutionConfig - pass this into RunSteps to control TTP execution
 type TTPExecutionConfig struct {
@@ -43,7 +47,8 @@ type TTPExecutionConfig struct {
 
 // TTPExecutionVars - mutable store to carry variables between steps
 type TTPExecutionVars struct {
-	WorkDir string
+	WorkDir  string
+	StepVars map[string]string
 }
 
 // TTPExecutionContext - holds config and context for the currently executing TTP
@@ -59,7 +64,10 @@ type TTPExecutionContext struct {
 // NewTTPExecutionContext creates a new TTPExecutionContext with empty config and created channels
 func NewTTPExecutionContext() TTPExecutionContext {
 	return TTPExecutionContext{
-		Vars:              &TTPExecutionVars{WorkDir: "/"},
+		Vars: &TTPExecutionVars{
+			WorkDir:  "/",
+			StepVars: make(map[string]string),
+		},
 		StepResults:       NewStepResultsRecord(),
 		actionResultsChan: make(chan *ActResult, 1),
 		errorsChan:        make(chan error, 1),
@@ -102,6 +110,29 @@ func (c TTPExecutionContext) ExpandVariables(inStrs []string) ([]string, error) 
 		expandedStrs = append(expandedStrs, expandedStr)
 	}
 	return expandedStrs, nil
+}
+
+// templateStep takes a string and templates it with variables from the context at this point in the TTP
+//
+// **Parameters:**
+//
+// input: the string to template
+//
+// **Returns:**
+//
+// string: the templated string
+// error: an error if there is a problem
+func (c TTPExecutionContext) templateStep(input string) (string, error) {
+	tmpl, err := template.New("BasicStep").Funcs(sprig.TxtFuncMap()).Option("missingkey=error").Delims(stepTemplateLeftDelim, stepTemplateRightDelim).Parse(input)
+	if err != nil {
+		return "", err
+	}
+	var output bytes.Buffer
+	err = tmpl.Execute(&output, c.Vars)
+	if err != nil {
+		return "", err
+	}
+	return output.String(), nil
 }
 
 func (c TTPExecutionContext) processStepsVariable(path string) (string, error) {

--- a/pkg/blocks/copypath.go
+++ b/pkg/blocks/copypath.go
@@ -70,6 +70,24 @@ func (s *CopyPathStep) Validate(_ TTPExecutionContext) error {
 	return nil
 }
 
+// Template takes each applicable field in the step and replaces any template strings with their resolved values.
+//
+// **Returns:**
+//
+// error: error if template resolution fails, nil otherwise
+func (s *CopyPathStep) Template(execCtx TTPExecutionContext) error {
+	var err error
+	s.Source, err = execCtx.templateStep(s.Source)
+	if err != nil {
+		return err
+	}
+	s.Destination, err = execCtx.templateStep(s.Destination)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Execute runs the step and returns an error if one occurs.
 func (s *CopyPathStep) Execute(_ TTPExecutionContext) (*ActResult, error) {
 	logging.L().Infof("Copying file(s) from %v to %v", s.Source, s.Destination)

--- a/pkg/blocks/createfile.go
+++ b/pkg/blocks/createfile.go
@@ -66,6 +66,24 @@ func (s *CreateFileStep) Validate(_ TTPExecutionContext) error {
 	return nil
 }
 
+// Template takes each applicable field in the step and replaces any template strings with their resolved values.
+//
+// **Returns:**
+//
+// error: error if template resolution fails, nil otherwise
+func (s *CreateFileStep) Template(execCtx TTPExecutionContext) error {
+	var err error
+	s.Path, err = execCtx.templateStep(s.Path)
+	if err != nil {
+		return err
+	}
+	s.Contents, err = execCtx.templateStep(s.Contents)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Execute runs the step and returns an error if one occurs.
 func (s *CreateFileStep) Execute(_ TTPExecutionContext) (*ActResult, error) {
 	logging.L().Infof("Creating file %v", s.Path)

--- a/pkg/blocks/editstep.go
+++ b/pkg/blocks/editstep.go
@@ -121,6 +121,24 @@ func (s *EditStep) Validate(execCtx TTPExecutionContext) error {
 	return nil
 }
 
+// Template takes each applicable field in the step and replaces any template strings with their resolved values.
+//
+// **Returns:**
+//
+// error: error if template resolution fails, nil otherwise
+func (s *EditStep) Template(execCtx TTPExecutionContext) error {
+	var err error
+	s.FileToEdit, err = execCtx.templateStep(s.FileToEdit)
+	if err != nil {
+		return err
+	}
+	s.BackupFile, err = execCtx.templateStep(s.BackupFile)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Execute runs the step and returns an error if one occurs.
 func (s *EditStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 	fileSystem := s.FileSystem
@@ -160,7 +178,6 @@ func (s *EditStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 	// but it's unlikely to be a performance issue in practice. If it is,
 	// we can optimize
 	for editIdx, edit := range s.Edits {
-
 		if edit.Append != "" {
 			contents += "\n" + edit.Append
 			continue

--- a/pkg/blocks/expectstep.go
+++ b/pkg/blocks/expectstep.go
@@ -127,6 +127,38 @@ func (s *ExpectStep) Validate(_ TTPExecutionContext) error {
 	return nil
 }
 
+// Template takes each applicable field in the step and replaces any template strings with their resolved values.
+//
+// **Returns:**
+//
+// error: error if template resolution fails, nil otherwise
+func (step *ExpectStep) Template(execCtx TTPExecutionContext) error {
+	var err error
+	step.Chdir, err = execCtx.templateStep(step.Chdir)
+	if err != nil {
+		return err
+	}
+	step.Executor, err = execCtx.templateStep(step.Executor)
+	if err != nil {
+		return err
+	}
+	step.Expect.Inline, err = execCtx.templateStep(step.Expect.Inline)
+	if err != nil {
+		return err
+	}
+	for i := range step.Expect.Responses {
+		step.Expect.Responses[i].Prompt, err = execCtx.templateStep(step.Expect.Responses[i].Prompt)
+		if err != nil {
+			return err
+		}
+		step.Expect.Responses[i].Response, err = execCtx.templateStep(step.Expect.Responses[i].Response)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Execute runs the step and returns an error if one occurs.
 //
 // **Parameters:**

--- a/pkg/blocks/loader.go
+++ b/pkg/blocks/loader.go
@@ -98,8 +98,7 @@ func RenderTemplatedTTP(ttpStr string, rp RenderParameters) (*TTP, error) {
 // *TTP: Pointer to the created TTP instance, or nil if the file is empty or invalid.
 // TTPExecutionContext: the initialized TTPExecutionContext suitable for passing to TTP.Execute(...)
 // err: An error if the file contains invalid data or cannot be read.
-func LoadTTP(ttpFilePath string, fsys afero.Fs, execCfg *TTPExecutionConfig, argsKvStrs []string) (*TTP, *TTPExecutionContext, error) {
-
+func LoadTTP(ttpFilePath string, fsys afero.Fs, execCfg *TTPExecutionConfig, stepVars map[string]string, argsKvStrs []string) (*TTP, *TTPExecutionContext, error) {
 	ttpBytes, err := readTTPBytes(ttpFilePath, fsys)
 	if err != nil {
 		return nil, nil, err
@@ -153,16 +152,10 @@ func LoadTTP(ttpFilePath string, fsys afero.Fs, execCfg *TTPExecutionConfig, arg
 		ttp.WorkDir = wd
 	}
 
-	execCtx := TTPExecutionContext{
-		Cfg: *execCfg,
-		Vars: &TTPExecutionVars{
-			WorkDir: ttp.WorkDir,
-		},
-		StepResults:       NewStepResultsRecord(),
-		actionResultsChan: make(chan *ActResult, 1),
-		errorsChan:        make(chan error, 1),
-		shutdownChan:      SetupSignalHandler(),
-	}
+	execCtx := NewTTPExecutionContext()
+	execCtx.Cfg = *execCfg
+	execCtx.Vars.WorkDir = ttp.WorkDir
+	execCtx.Vars.StepVars = stepVars
 
 	err = ttp.Validate(execCtx)
 	if err != nil {

--- a/pkg/blocks/printstr.go
+++ b/pkg/blocks/printstr.go
@@ -55,6 +55,20 @@ func (s *PrintStrAction) Validate(_ TTPExecutionContext) error {
 	return nil
 }
 
+// Template takes each applicable field in the step and replaces any template strings with their resolved values.
+//
+// **Returns:**
+//
+// error: error if template resolution fails, nil otherwise
+func (step *PrintStrAction) Template(execCtx TTPExecutionContext) error {
+	var err error
+	step.Message, err = execCtx.templateStep(step.Message)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Execute runs the step and returns an error if one occurs.
 func (s *PrintStrAction) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 	// needs to be overwritable to capture output during testing

--- a/pkg/blocks/removepath.go
+++ b/pkg/blocks/removepath.go
@@ -61,6 +61,20 @@ func (s *RemovePathAction) Validate(_ TTPExecutionContext) error {
 	return nil
 }
 
+// Template takes each applicable field in the step and replaces any template strings with their resolved values.
+//
+// **Returns:**
+//
+// error: error if template resolution fails, nil otherwise
+func (s *RemovePathAction) Template(execCtx TTPExecutionContext) error {
+	var err error
+	s.Path, err = execCtx.templateStep(s.Path)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Execute runs the step and returns an error if one occurs.
 func (s *RemovePathAction) Execute(_ TTPExecutionContext) (*ActResult, error) {
 	logging.L().Infof("Removing path %v", s.Path)

--- a/pkg/blocks/step.go
+++ b/pkg/blocks/step.go
@@ -166,6 +166,19 @@ func (s *Step) Validate(execCtx TTPExecutionContext) error {
 	return nil
 }
 
+// Template replaces variables in the step action and cleanup
+func (s *Step) Template(execCtx TTPExecutionContext) error {
+	if err := s.action.Template(execCtx); err != nil {
+		return err
+	}
+	if s.cleanup != nil {
+		if err := s.cleanup.Template(execCtx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Execute runs the action associated with this step and sends result/error to channels of the context
 func (s *Step) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 	desc := s.action.GetDescription()

--- a/pkg/blocks/subttp_test.go
+++ b/pkg/blocks/subttp_test.go
@@ -71,12 +71,15 @@ steps:
 func TestSubTTPExecution(t *testing.T) {
 
 	tests := []struct {
-		name           string
-		spec           repos.Spec
-		fsys           afero.Fs
-		stepYAML       string
-		expectError    bool
-		expectedOutput string
+		name                 string
+		spec                 repos.Spec
+		fsys                 afero.Fs
+		stepYAML             string
+		stepVars             map[string]string
+		expectValidationErr  bool
+		expectTemplateError  bool
+		expectExecutionError bool
+		expectedOutput       string
 	}{
 		{
 			name: "Simple Sub TTP Execution",
@@ -114,6 +117,71 @@ args:
 ttp: with/cleanup.yaml`,
 			expectedOutput: "sub_step_1_output\nsub_step_2_output\n",
 		},
+		{
+			name: "Sub TTP Execution with templated Args",
+			spec: repos.Spec{
+				Name: "default",
+				Path: "repos/a",
+			},
+			fsys: makeTestFsForSubTTPs(t),
+			stepYAML: `name: with-args
+ttp: another/args.yaml
+args:
+  arg_number_one: "{[{.StepVars.arg1}]}"
+  arg_number_two: world`,
+			expectedOutput: "hello world victory",
+			stepVars: map[string]string{
+				"arg1": "hello",
+			},
+		},
+		{
+			name: "Sub TTP Execution with templated ttp",
+			spec: repos.Spec{
+				Name: "default",
+				Path: "repos/a",
+			},
+			fsys: makeTestFsForSubTTPs(t),
+			stepYAML: `name: with-args
+ttp: another/{[{.StepVars.ttpname}]}.yaml
+args:
+  arg_number_one: "hello"
+  arg_number_two: world`,
+			stepVars: map[string]string{
+				"ttpname": "args",
+			},
+			expectedOutput: "hello world victory",
+		},
+		{
+			name: "Sub TTP Execution fails on missing args",
+			spec: repos.Spec{
+				Name: "default",
+				Path: "repos/a",
+			},
+			fsys: makeTestFsForSubTTPs(t),
+			stepYAML: `name: with-args
+ttp: another/args.yaml
+args:
+  arg_number_one: "{[{.StepVars.arg1}]}"
+  arg_number_two: world`,
+			expectTemplateError: true,
+		},
+		{
+			name: "Sub TTP Execution fails on missing templated ttp reference",
+			spec: repos.Spec{
+				Name: "default",
+				Path: "repos/a",
+			},
+			fsys: makeTestFsForSubTTPs(t),
+			stepYAML: `name: with-args
+ttp: another/{[{.StepVars.ttpname}]}.yaml
+args:
+  arg_number_one: "hello"
+  arg_number_two: world`,
+			stepVars: map[string]string{
+				"ttpname": "wtf",
+			},
+			expectTemplateError: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -125,16 +193,37 @@ ttp: with/cleanup.yaml`,
 			repo, err := tc.spec.Load(tc.fsys, "")
 			require.NoError(t, err)
 
+			// prepare the execution context
 			execCtx := NewTTPExecutionContext()
 			execCtx.Cfg = TTPExecutionConfig{
 				Repo: repo,
 			}
+			execCtx.Vars.StepVars = tc.stepVars
 
+			// validate the step
 			err = step.Validate(execCtx)
-			require.NoError(t, err, "step failed to validate")
-
-			result, err := step.Execute(execCtx)
+			if tc.expectValidationErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
+
+			// template the step
+			err = step.Template(execCtx)
+			if tc.expectTemplateError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// execute the step
+			result, err := step.Execute(execCtx)
+			if tc.expectExecutionError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
 			assert.Equal(t, tc.expectedOutput, result.Stdout)
 		})
 	}

--- a/pkg/blocks/subttpcleanup.go
+++ b/pkg/blocks/subttpcleanup.go
@@ -32,7 +32,12 @@ func (a *subTTPCleanupAction) IsNil() bool {
 }
 
 // Validate is not needed here, as this is not a user-accessible step type
-func (a *subTTPCleanupAction) Validate(execCtx TTPExecutionContext) error {
+func (a *subTTPCleanupAction) Validate(_ TTPExecutionContext) error {
+	return nil
+}
+
+// Template is not needed here, as this is not a user-accessible step type
+func (a *subTTPCleanupAction) Template(_ TTPExecutionContext) error {
 	return nil
 }
 

--- a/pkg/blocks/ttps.go
+++ b/pkg/blocks/ttps.go
@@ -166,7 +166,11 @@ func (t *TTP) RunSteps(execCtx TTPExecutionContext) error {
 		logging.L().Infof("Executing Step #%d: %q", stepIdx+1, step.Name)
 		// core execution - run the step action
 		go func(step Step) {
-			_, err := step.Execute(execCtx)
+			err := step.Template((execCtx))
+			if err != nil {
+				logging.L().Errorf("Error templating step %s: %v", step.Name, err)
+			}
+			_, err = step.Execute(execCtx)
 			if err != nil {
 				// This error was logged by the step itself
 				logging.L().Debugf("Error executing step %s: %v", step.Name, err)


### PR DESCRIPTION
Summary:
Create the ability to dynamically set variables based on step outputs and then use them in subsequent steps.  This is achieved via two large changes:
- All steps take an `outputvar` value, and each step manually defines how it sets this value.  Steps where it doesn't make sense to have an output variable just do nothing with this value.
  - Inline step pipes any stdout output to a variable
  - HTTPRequest step pipes response body (or regex result of response body if set) to a variable
  - FetchURI step pipes the entire content output to a variable
  - All other steps do not currently define an output
- All steps now do a second templating step at step load time using these tags `{[{ ... }]}`. All steps now have a Template method, which each step needs to define to manually specify which variables will be templated.  We do this because TTPForge by default only templates once before loading the YAML.

Differential Revision: D71841703
