### PR TITLE
TTPForge StepVars Bugfix: Fix newline appended to stdout

### DIFF
--- a/pkg/blocks/basicstep.go
+++ b/pkg/blocks/basicstep.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/facebookincubator/ttpforge/pkg/logging"
@@ -120,7 +121,7 @@ func (b *BasicStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 	}
 	// Send stdout to the output variable
 	if b.OutputVar != "" {
-		execCtx.Vars.StepVars[b.OutputVar] = result.Stdout
+		execCtx.Vars.StepVars[b.OutputVar] = strings.TrimSuffix(result.Stdout, "\n")
 	}
 	return result, nil
 }


### PR DESCRIPTION
Summary:
In inline blocks, when we capture stdout to a variable, we include the newline character used to move the cursor to a fresh line.  While this is technically correct, most users would expect something like `echo "asdf"` to load the variable with `asdf`, not `asdf\n`.

To fix this, I've opted just to remove a single newline from the end of stdout before loading it into the variable.

Differential Revision: D78497399


