### PR TITLE
Kill Process Improvements

### DIFF
--- a/docs/foundations/actions/kill_process.md
+++ b/docs/foundations/actions/kill_process.md
@@ -3,7 +3,8 @@
 The `kill_process` action can be used to terminate processes running on a system.
 Check out the TTP below to see how it works:
 
-<!-- TODO: Link to add for example TTP after code is landed -->
+[Kill Process Unix](https://github.com/facebookincubator/TTPForge/blob/0deabc567751d90078e5db3c2a84574396b43dc1/example-ttps/actions/kill-process/kill-process-unix.yaml)
+[Kill Process Windows](https://github.com/facebookincubator/TTPForge/blob/0deabc567751d90078e5db3c2a84574396b43dc1/example-ttps/actions/kill-process/kill-process-windows.yaml)
 
 You can experiment with the above TTP by installing the `examples` TTP
 repository (skip this if `ttpforge list repos` shows that the `examples` repo is
@@ -27,6 +28,10 @@ You can specify the following YAML fields for the `kill_process:` action:
 you wish to kill
 - `kill_process_name:` (type: `string`) the process name of the process that
 you wish to kill
+- `error_on_find_process_failure:` (type: `bool`) whether to raise an error if
+finding the process name/id fails
+- `error_on_kill_failure:` (type: `bool`) whether to raise an error if killing
+ the process fails
 
 ## Additional Notes
 
@@ -34,3 +39,5 @@ If both `kill_process_id` and `kill_process_name` are specified, the action
 will only consider process ID as long as it is valid.
 If an invalid `kill_process_id` is specified, the action will fall back to
 using `kill_process_name` to kill the processes.
+Both the flags `error_on_find_process_failure` and `error_on_kill_failure` are
+set to `false` by default.

--- a/example-ttps/actions/kill-process/kill-process-unix-failure.yaml
+++ b/example-ttps/actions/kill-process/kill-process-unix-failure.yaml
@@ -1,9 +1,9 @@
 ---
 api_version: 2.0
-uuid: bc5bb5b9-d1a1-479c-93fd-843f415276e3
-name: "Kill Process Unix"
+uuid: fbf458fb-c351-4633-97b6-67332f94b7c1
+name: "Kill Process Unix Failure"
 description: |
-  "This is an example TTP that kills a ping process on a Unix system"
+  "This is an example TTP that kills a ping process on a Unix system that does not exist"
 requirements:
   platforms:
     - os: linux
@@ -20,8 +20,9 @@ steps:
       echo "================="
   - name: Killing the ping process
     kill_process_id: ""
-    kill_process_name: "ping"
-    error_on_find_process_failure: true
+    kill_process_name: "ping123"
+    error_on_find_process_failure: false
+    error_on_kill_process_failure: false
   - name: Show processes
     inline: |
       ps aux | grep ping

--- a/example-ttps/actions/kill-process/kill-process-windows-failure.yaml
+++ b/example-ttps/actions/kill-process/kill-process-windows-failure.yaml
@@ -1,0 +1,27 @@
+---
+api_version: 2.0
+uuid: eb38a84b-837b-47d9-9373-3d35a824b003
+name: "Kill Process Windows Failure"
+description: |
+  "This is an example TTP that kills a ping process on a Windows system that does not exist"
+requirements:
+  platforms:
+    - os: windows
+steps:
+  - name: Process to kill started using python
+    executor: cmd
+    inline: |
+      tasklist | findstr PING.EXE
+      echo "Starting the detached ping process to be killed"
+      python3 -c "import subprocess,os; subprocess.Popen(['ping', '-n', '10', '127.0.0.1'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, creationflags=8)"
+      echo "================="
+      tasklist | findstr PING.EXE
+      echo "================="
+  - name: Killing the ping process
+    kill_process_id: ""
+    kill_process_name: "PING123"
+    error_on_find_process_failure: false
+  - name: Show processes
+    executor: cmd
+    inline: |
+      tasklist | findstr PING.EXE

--- a/pkg/blocks/killprocess_test.go
+++ b/pkg/blocks/killprocess_test.go
@@ -20,7 +20,6 @@ THE SOFTWARE.
 package blocks
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"testing"
@@ -42,33 +41,59 @@ func TestKillProcessExecute(t *testing.T) {
 		expectValidateError bool
 	}{
 		{
-			name:        "Kill non-existent process with process id",
+			name:        "Kill non-existent process with process id - throw error",
 			description: "Trying to kill a process with process id that doesn't exist",
 			step: &KillProcessStep{
-				ProcessID:   "123456789",
-				ProcessName: "ping",
+				ProcessID:                 "123",
+				ProcessName:               "ping",
+				ErrorOnFindProcessFailure: true,
 			},
 			createProcess:      false,
 			expectExecuteError: true,
 		},
 		{
-			name:        "Kill non-existent process with process name",
+			name:        "Kill non-existent process with process id - continue on error",
+			description: "Trying to kill a process with process id that doesn't exist",
+			step: &KillProcessStep{
+				ProcessID:                 "123456789",
+				ProcessName:               "ping",
+				ErrorOnFindProcessFailure: false,
+				ErrorOnKillFailure:        false,
+			},
+			createProcess:      false,
+			expectExecuteError: false,
+		},
+		{
+			// Test might throw an error on stress run
+			name:        "Kill non-existent process with process name - throw error",
+			description: "Trying to kill a process with process name that doesn't exist",
+			step: &KillProcessStep{
+				ProcessID:                 "",
+				ProcessName:               "ping",
+				ErrorOnFindProcessFailure: true,
+			},
+			createProcess:      false,
+			expectExecuteError: true,
+		},
+		{
+			name:        "Kill non-existent process with process name - continue on error",
 			description: "Trying to kill a process with process name that doesn't exist",
 			step: &KillProcessStep{
 				ProcessID:   "",
 				ProcessName: "ping",
 			},
 			createProcess:      false,
-			expectExecuteError: true,
+			expectExecuteError: false,
 		},
 		{
-			name:        "Kill existent process with process id",
+			name:        "Kill non-existent process with process id",
 			description: "Trying to kill a process with process id that exists",
 			step: &KillProcessStep{
 				ProcessID:   "123456789",
 				ProcessName: "ping",
 			},
-			createProcess: true,
+			createProcess:      true,
+			expectExecuteError: false,
 		},
 		{
 			name:        "Kill existent process with process name",
@@ -77,7 +102,8 @@ func TestKillProcessExecute(t *testing.T) {
 				ProcessID:   "",
 				ProcessName: "ping",
 			},
-			createProcess: true,
+			createProcess:      true,
+			expectExecuteError: false,
 		},
 		{
 			name:        "Kill process invalid process id",
@@ -110,8 +136,9 @@ func TestKillProcessExecute(t *testing.T) {
 			name:        "Kill process ID with templating",
 			description: "Trying to kill a process with templating",
 			step: &KillProcessStep{
-				ProcessID:   "{[{.StepVars.pid}]}",
-				ProcessName: "ping",
+				ProcessID:                 "{[{.StepVars.pid}]}",
+				ProcessName:               "ping",
+				ErrorOnFindProcessFailure: true,
 			},
 			stepVars: map[string]string{
 				"pid": "123456789",
@@ -124,8 +151,9 @@ func TestKillProcessExecute(t *testing.T) {
 			name:        "Kill process name with templating",
 			description: "Trying to kill a process with process name and templating",
 			step: &KillProcessStep{
-				ProcessID:   "",
-				ProcessName: "{[{.StepVars.processName}]}",
+				ProcessID:                 "",
+				ProcessName:               "{[{.StepVars.processName}]}",
+				ErrorOnFindProcessFailure: true,
 			},
 			stepVars: map[string]string{
 				"processName": "touch",
@@ -175,7 +203,6 @@ func TestKillProcessExecute(t *testing.T) {
 				require.Error(t, err2)
 				return
 			}
-			fmt.Printf(tc.step.ProcessID)
 			require.NoError(t, err2)
 
 			if tc.createProcess {

--- a/pkg/processutils/processutils.go
+++ b/pkg/processutils/processutils.go
@@ -42,3 +42,17 @@ func GetPIDsByName(processName string) ([]int32, error) {
 	}
 	return pids, nil
 }
+
+// VerifyPIDExists returns a boolean basis if a process with the input PID exists
+func VerifyPIDExists(pid int) error {
+	processes, err := process.Processes()
+	if err != nil {
+		return err
+	}
+	for _, proc := range processes {
+		if int(proc.Pid) == pid {
+			return nil
+		}
+	}
+	return fmt.Errorf("No process found with PID: %d", pid)
+}

--- a/pkg/processutils/processutils_unix_test.go
+++ b/pkg/processutils/processutils_unix_test.go
@@ -1,0 +1,129 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package processutils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/facebookincubator/ttpforge/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPidsByName(t *testing.T) {
+
+	testCases := []struct {
+		name                  string
+		processName           string
+		processExists         bool
+		expectEntriesInResult bool
+	}{
+		{
+			name:                  "Process Exists",
+			processName:           "ping",
+			processExists:         true,
+			expectEntriesInResult: true,
+		},
+		{
+			name:                  "Process Does Not Exist",
+			processName:           "pingabc",
+			processExists:         false,
+			expectEntriesInResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// Setup
+			var pid int
+			var error error
+			if tc.processExists {
+				pid, error = testutils.CreateProcessToTerminate()
+				require.NoError(t, error)
+			}
+			// Testing
+			result, err := GetPIDsByName(tc.processName)
+			if len(result) > 0 {
+				assert.Equal(t, tc.expectEntriesInResult, true)
+
+				foundOurPid := false
+				// Cleanup
+				for _, p := range result {
+					if int(p) == pid {
+						foundOurPid = true
+						process, err := os.FindProcess(int(p))
+						if err != nil {
+							continue
+						}
+						process.Kill()
+						// Need to wait for the process to be reaped by the OS (Completely killed)
+						_, err = process.Wait()
+						require.NoError(t, err)
+					}
+				}
+				assert.Equal(t, foundOurPid, true)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, tc.expectEntriesInResult, false)
+			}
+
+		})
+	}
+}
+
+// Only PID=1 is always running in Unix & Linux but not windows
+func TestVerifyPIDExists(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		pid         int
+		expectError bool
+	}{
+		{
+			name:        "Process Exists",
+			pid:         1,
+			expectError: false,
+		},
+		{
+			name:        "Process Does Not Exist",
+			pid:         124567890987654321,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// Testing
+			err := VerifyPIDExists(tc.pid)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/run-all-ttp-tests.sh
+++ b/run-all-ttp-tests.sh
@@ -28,7 +28,7 @@ then
 fi
 TTPFORGE_BINARY=$(realpath "${TTPFORGE_BINARY}")
 
-EXCEPTIONS_FILE=["kill-process-windows.yaml"]
+EXCEPTIONS_FILE=["kill-process-windows.yaml","kill-process-windows-failure.yaml"]
 
 # Loop over all specified directories and validate all ttps within each.
 shift


### PR DESCRIPTION
Summary:
### Context
Currently the `kill_process` action in TTPForge in cases of failure like `Couldn't find process` and `Couldn't kill process` by default throws an exception which leads to TTP being stopped. While this could be a valid usecase in some situations, allowing user control on whether to throw an error or to print an error and return normally helps make the code versatile.

Following is the decision making in the initial commit of Kill Process Action: [link](https://app.diagrams.net/#G1A4S3RgNffbaMbp40RCpqvmprH1QQvVvi#%7B%22pageId%22%3A%22CNsj_rZLfA5pAP3afiLK%22%7D)
https://pxl.cl/7Lcn3
This flow diagram shows the updated decision making: [link](https://app.diagrams.net/?title=Kill%20Process%20Updated%20Decision%20making.drawio&client=1#G1TePfzl48hKjTKe-K-efOH8F-ASMror7j#%7B%22pageId%22%3A%22CNsj_rZLfA5pAP3afiLK%22%7D)
https://pxl.cl/7Lcmh

### Changes

*   **Code Improvements**: The `kill_process` step has been updated to receive user inputs on actions to take in case of failures like `error_on_find_process_failure` and `error_on_kill_failure`. This facilitates increased control on the code flow by the user to satisfy different needs.
*   **Documentation**: Added an example TTP for reference on the use of the new user inputs for the step `kill_process`.
*   **Testing**: Additional test cases have been added to verify the functionality of the added flags on the `kill_process` step.

### Impact

*   **Improved Usability**: The changes in this diff make it easier for users to control the output of the step on the basis of their needs. (Ignoring or throwing exceptions in cases of failure)

Reviewed By: d0n601

Differential Revision: D78521586
