### PR TITLE
Update Goreleaser to ignore WIndows ARM Builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 ---
+version: 2
 builds:
   - id: "ttpforge"
     binary: ttpforge
@@ -22,3 +23,7 @@ builds:
     goamd64:
       - v2
       - v3
+    # Ignore Windows arm is not compatable with gopsutil.
+    ignore:
+      - goos: windows
+        goarch: arm


### PR DESCRIPTION
Summary: Ignoring ARM builds on Windows because of a dependency error with gopsutils

Reviewed By: Harshit-Mashru, samdlinn

Differential Revision: D78753717


