### PR TITLE
Goreleaser Version set to 1

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,4 @@
 ---
-version: 2
 builds:
   - id: "ttpforge"
     binary: ttpforge


### PR DESCRIPTION
Summary: Specify Goreleaser to use version 1 for Github compatability.

Differential Revision: D78761882


