### PR TITLE
Parse YAML TTPs

### DIFF
--- a/pkg/parseutils/parsefile.go
+++ b/pkg/parseutils/parsefile.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package parseutils
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Arg is a struct that represents the information of an argument in a TTP in a YAML file.
+type Arg struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+	Type        string `yaml:"type,omitempty"`
+	Choices     []any  `yaml:"choices,omitempty"`
+	Default     any    `yaml:"default,omitempty"`
+}
+
+// Mitre is a struct that represents a MITRE tactic, technique, or subtechnique in a YAML file.
+type Mitre struct {
+	Tactics       []string `yaml:"tactics,omitempty"`
+	Techniques    []string `yaml:"techniques,omitempty"`
+	Subtechniques []string `yaml:"subtechniques,omitempty"`
+}
+
+// Platform is a struct that represents a platform in a YAML file like Windows, Linux, etc.
+type Platform struct {
+	OS string `yaml:"os"`
+}
+
+// Requirements is a struct that represents the requirements of a TTP in a YAML file like Platform (OS), superuser, etc.
+type Requirements struct {
+	Platforms []Platform `yaml:"platforms,omitempty"`
+	Superuser bool       `yaml:"superuser,omitempty"`
+}
+
+// TTP is a struct that represents a TTP in a YAML file.
+type TTP struct {
+	APIVersion   string       `yaml:"api_version"`
+	UUID         string       `yaml:"uuid"`
+	Name         string       `yaml:"name"`
+	Description  string       `yaml:"description"`
+	Requirements Requirements `yaml:"requirements,omitempty"`
+	Mitre        Mitre        `yaml:"mitre,omitempty"`
+	Args         []Arg        `yaml:"args,omitempty"`
+}
+
+// ParseTTP parses a YAML file and returns a map of the contents.
+func ParseTTP(data []byte, filename string) (TTP, error) {
+	// Find steps: in data
+	stepsIndex := bytes.Index(data, []byte("\nsteps:"))
+	if stepsIndex != -1 {
+		data = data[:stepsIndex+1]
+	}
+	var ttp TTP
+	if err := yaml.Unmarshal(data, &ttp); err != nil {
+		return TTP{}, fmt.Errorf("Failed to unmarshal file %s: %w", filename, err)
+	}
+	return ttp, nil
+}

--- a/pkg/parseutils/parsefile_test.go
+++ b/pkg/parseutils/parsefile_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package parseutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTTP(t *testing.T) {
+	tests := []struct {
+		name        string
+		ttpStr      string
+		expectError bool
+	}{
+		{
+			name: "valid ttp",
+			ttpStr: `name: valid ttp
+description: should pass parsing
+args:
+- name: arg1
+steps:
+- name: step1
+  inline: echo "arg value is {{ .Args.arg1 }}"
+- name: step2
+  inline: echo "step two"`,
+			expectError: false,
+		},
+		{
+			name: "duplicate args key",
+			ttpStr: `name: duplicate args key
+description: should fail parsing
+args:
+- name: step1
+  default: echo "step one"
+args:
+- name: step2
+  default: echo "step two"`,
+			expectError: true,
+		},
+		{
+			name: "No Steps Field",
+			ttpStr: `description: should fail linting due to args after steps
+args:
+- name: arg1"
+`,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseTTP([]byte(tc.ttpStr), tc.name+".yaml")
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary:
## Parse YAML TTPs

This diff introduces a new utility `parseutils` to TTPForge, which provides functionality to parse YAML TTPs. Using this, we updated the `enum ttps` command functionality.

This diff is a part of the future improvements discussed in the following [diff](https://www.internalfb.com/diff/D77619765).

### Context

Currently commands in TTPForge like Enum use the read file and regex functionalities to find certain data points in the YAML. This is not the most efficient way to extract/filter information from YAML as regex could lead to false positives and negatives.

To solve this problem, this diff implements parsing the YAML file to extract data on the basis of structures and updates the `enum ttps` command to use it as explored in this [document](https://docs.google.com/document/d/1OUihSxvrTHUK24kIH0VE3uHL-l6OBCL6iSPLIXLtx8E/edit?tab=t.0#heading=h.je60o44ihbi0).

### Impact
The added functionality allows **correct and easy data extraction** from TTPs also paving way for us to use this TTP data for other things like dashboard. This also promotes a more structured YAML file creation for TTPs going forward. This is highlighted by [TTPs](https://www.internalfb.com/code/security-ttpcode/ttps/purple-team-engagements/2025-Q2-Purple-Fleece/ttp01-exfil-model-to-s3-from-devserver-awscli/ttp.yaml) that were missed using the regex approach due to inverted commas being using in tactic and technique.

After implementing this diff, while testing we identified some TTPs that had errors. We also noted that when using the [security-ttpcode repo](https://www.internalfb.com/code/security-ttpcode/ttpforge-repo-config.yaml) gives us few redundant TTPs due to misconfiguration.

Following are the diffs created to fix the errors/improvements observed from this updated code while testing:
1) [Updating TTP Repo Config](https://www.internalfb.com/diff/D78836093)
2) [Fixing error in TTP for parsing](https://www.internalfb.com/diff/D78837976)
3) [Fixing TTP Platform Details](https://www.internalfb.com/diff/D78846851)

Diff 1 & 2 were identified due to parsing errors on TTPs observed on the `security-ttpcode` whereas diff 3 was identified due to the change in TTP count in the older and newer approach.

Apart from these 4 other TTP errors were identified and decisions are being made for these.

Overall, this diff aims to improve the functionality of TTPForge by adding support for parsing YAML TTPs, making it more accurate.

### Future Improvement
After looking into the errors, we have identified that creating a sandcastle job that runs the parsing code to validate new TTP created in any diff could be instrumental to the team.

Reviewed By: d0n601

Differential Revision: D78701235


