### PR TITLE
Adding parse-yaml functionality for sandcastle job

### DIFF
--- a/cmd/parseyaml.go
+++ b/cmd/parseyaml.go
@@ -1,0 +1,66 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/facebookincubator/ttpforge/pkg/parseutils"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+// This command is used to test the parsing of a TTP file when creating a diff as part of sandcastle job.
+func buildParseYamlCommand(cfg *Config) *cobra.Command {
+	runCmd := &cobra.Command{
+		Use:   "parse-yaml [repo_name//path/to/ttp]",
+		Short: "Parse YAML to convert to TTP structure.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// don't want confusing usage display for errors past this point
+			cmd.SilenceUsage = true
+
+			fs := afero.NewOsFs()
+
+			for _, ttpRef := range args {
+				_, path, err := cfg.repoCollection.ResolveTTPRef(ttpRef)
+				if err != nil {
+					fmt.Printf("Failed to resolve TTP reference %v: %v", ttpRef, err)
+					return err
+				}
+				content, err := afero.ReadFile(fs, path)
+				if err != nil {
+					fmt.Printf("Error reading TTP ref: %v on path %v with error: %v", ttpRef, path, err)
+					return err
+				}
+				_, err = parseutils.ParseTTP(content, path)
+				// Can add field enforcement here in future...
+				if err != nil {
+					fmt.Printf("Error parsing TTP ref: %v with error: %v\n", ttpRef, err)
+					return err
+				}
+				fmt.Println("Successfully Parsed TTP: ", ttpRef)
+			}
+			return nil
+		},
+	}
+	return runCmd
+}

--- a/cmd/parseyaml_test.go
+++ b/cmd/parseyaml_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseYaml(t *testing.T) {
+	testConfigFilePath := filepath.Join("test-resources", "test-config.yaml")
+	testCases := []struct {
+		name      string
+		ttpRef    string
+		wantError bool
+	}{
+		{
+			name:      "Successful parse",
+			ttpRef:    "enum-repo//platform-darwin.yaml",
+			wantError: false,
+		},
+		{
+			name:      "Unsuccessful parse",
+			ttpRef:    "enum-repo//platform-darwin1234.yaml",
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rc := BuildRootCommand(nil)
+			rc.SetArgs([]string{"parse-yaml", tc.ttpRef, "-c", testConfigFilePath})
+			err := rc.Execute()
+			if tc.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,5 +84,6 @@ TTPForge is a Purple Team engagement tool to execute Tactics, Techniques, and Pr
 	rootCmd.AddCommand(buildTestCommand(cfg))
 	rootCmd.AddCommand(buildInstallCommand(cfg))
 	rootCmd.AddCommand(buildRemoveCommand(cfg))
+	rootCmd.AddCommand(buildParseYamlCommand(cfg))
 	return rootCmd
 }

--- a/parse-diff-ttps-test.sh
+++ b/parse-diff-ttps-test.sh
@@ -28,27 +28,18 @@ then
 fi
 TTPFORGE_BINARY=$(realpath "${TTPFORGE_BINARY}")
 
-EXCEPTIONS_FILE=("kill-process-windows.yaml" "kill-process-windows-failure.yaml")
+TTP_BASE_DIR="$2"
 
-# Loop over all specified directories and validate all ttps within each.
-shift
-for TTP_DIR in "$@"; do
-  # validate directory
-  if [ ! -d "${TTP_DIR}" ]
-  then
-    echo "Invalid TTP Directory Specified!"
-    exit 1
-  fi
-  TTP_DIR=$(realpath "${TTP_DIR}")
+shift 2
 
-  TTP_FILE_LIST="$(find "${TTP_DIR}" -name "*.yaml")"
-  for TTP_FILE in ${TTP_FILE_LIST}
-  do
-      echo "Running TTP: ${TTP_FILE}"
-      if [[ "${EXCEPTIONS_FILE[*]}" =~ ${TTP_FILE##*/} ]]; then
-        echo "Skipping TTP: ${TTP_FILE}"
-        continue
-      fi
-      ${TTPFORGE_BINARY} test "${TTP_FILE}"
-  done
+full_paths=()
+for file in "$@"; do
+  echo "Processing input: $file"
+  ttp_ref="${TTP_BASE_DIR}/${file}"
+  echo "TTP Path: $ttp_ref"
+  full_paths+=("$ttp_ref")
 done
+
+echo "Processing following TTPs:" "${full_paths[@]}"
+
+${TTPFORGE_BINARY} parse-yaml "${full_paths[@]}"


### PR DESCRIPTION
Summary:
### TTPForge Enhancement: Parse-YAML Functionality for Sandcastle Job

This diff introduces a new command `parse-yaml` to the TTPForge tool. The command accepts TTP reference as an argument and reads & tries to parse them using the `parseutils`. In case of any failure it returns an error. In this diff we also create a bash file that is called by the sandcastle job with all the affected file names. The bash files calls parse-yaml functionality for the TTPs in a for loop. This enables the sandcastle job to check & ensure that all the affected TTPs have correct structure.

#### New Files Added

* `fbcode/security/redteam/purple_team/ttpforge/cmd/parseyaml.go`: Implements the parse-YAML functionality.
* `fbcode/security/redteam/purple_team/ttpforge/cmd/parseyaml_test.go`: Contains unit tests for the parse-YAML feature.
* `fbcode/security/redteam/purple_team/ttpforge/parse-diff-ttps-test.sh`: Script called by sandcastle job that runs the parse-YAML functionality for all TTPs given to it.

These changes collectively enhance the functionality of TTPForge by adding a command to parse YAML files and making it more versatile for Sandcastle jobs.

Reviewed By: ivnik

Differential Revision: D79202811


