### PR TITLE
Add args to ttpforgre create TTP Boilerplate

### DIFF
--- a/cmd/createttp.go
+++ b/cmd/createttp.go
@@ -46,6 +46,10 @@ mitre:
     - {{.Placeholder}}
   subtechniques:
     - {{.Placeholder}}
+args:
+  - name: {{.Placeholder}}
+    description: {{.Placeholder}}
+    default: {{.Placeholder}}
 steps:
   - name: hello_world
     inline: |


### PR DESCRIPTION
Summary:
Update TTPForge create ttp command to add args to created boilerplate file

Currently, it's not apparent that TTPForge support arguments just by looking at the generated boilerplate. While it is obvious to humans by reading TTPForge documentation, LLM Agents waste a few hundred tokens to figure out the exact syntax of adding arguments.

This change is expected to fix that issue and make it easier to infer format to add arguments

Differential Revision: D79562207
