### PR TITLE
TTPForge Move Command

### DIFF
--- a/cmd/move.go
+++ b/cmd/move.go
@@ -1,0 +1,198 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/facebookincubator/ttpforge/pkg/repos"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func findAndReplaceTTPReferences(rc repos.RepoCollection, fs afero.Fs, sourceRepo repos.Repo, sourceRef string, replacement string) error {
+	// Parse source reference
+	index := strings.Index(sourceRef, repos.RepoPrefixSep)
+	if index == -1 {
+		return fmt.Errorf("invalid source reference format: %s", sourceRef)
+	}
+
+	scopedRef := sourceRef[index+2:]
+
+	// Build patterns for finding references in ttp: YAML fields:
+	// 1. Full reference: ttp: examples//actions/inline/basic.yaml
+	// 2. Scoped reference: ttp: //actions/inline/basic.yaml
+	// 3. Bare reference: ttp: actions/inline/basic.yaml (legacy compatibility)
+	// These patterns match the entire ttp: field value including any surrounding whitespace
+	fullRefPattern := regexp.MustCompile(`(\s*ttp:\s*)` + regexp.QuoteMeta(sourceRef) + `(\s*)`)
+	scopedRefPattern := regexp.MustCompile(`(\s*ttp:\s*)` + regexp.QuoteMeta(repos.RepoPrefixSep+scopedRef) + `(\s*)`)
+	bareRefPattern := regexp.MustCompile(`(\s*ttp:\s*)` + regexp.QuoteMeta(scopedRef) + `(\s*)`)
+
+	ttpRefs, err := rc.ListTTPs()
+	if err != nil {
+		return fmt.Errorf("failed to list TTPs: %w", err)
+	}
+
+	for _, ttpRef := range ttpRefs {
+		repo, ttpAbsPath, err := rc.ResolveTTPRef(ttpRef)
+		if err != nil {
+			return fmt.Errorf("failed to resolve TTP reference %v: %w", ttpRef, err)
+		}
+
+		content, err := afero.ReadFile(fs, ttpAbsPath)
+		if err != nil {
+			return fmt.Errorf("failed to read TTP %v: %w", ttpRef, err)
+		}
+
+		var updated bool
+		var newContent []byte
+
+		// Priority 1: Full reference match (examples//actions/inline/basic.yaml)
+		if fullRefPattern.Match(content) {
+			newContent = fullRefPattern.ReplaceAll(content, []byte("${1}"+replacement+"${2}"))
+			updated = true
+		} else if repo.GetName() == sourceRepo.GetName() {
+			// Priority 2: Scoped reference match (//actions/inline/basic.yaml)
+			if scopedRefPattern.Match(content) {
+				newContent = scopedRefPattern.ReplaceAll(content, []byte("${1}"+replacement+"${2}"))
+				updated = true
+			} else if bareRefPattern.Match(content) {
+				// Priority 3: Bare reference match (actions/inline/basic.yaml) - legacy compatibility
+				newContent = bareRefPattern.ReplaceAll(content, []byte("${1}"+replacement+"${2}"))
+				updated = true
+			}
+		}
+
+		if updated {
+			if err := afero.WriteFile(fs, ttpAbsPath, newContent, 0644); err != nil {
+				return fmt.Errorf("failed to write updated content to %v: %w", ttpRef, err)
+			}
+			fmt.Printf("Updated TTP subdependency in %s\n", ttpRef)
+		}
+	}
+
+	return nil
+}
+
+func moveFile(fs afero.Fs, sourceAbsPath, destAbsPath string) error {
+	destDir := filepath.Dir(destAbsPath)
+	if err := fs.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	if err := fs.Rename(sourceAbsPath, destAbsPath); err != nil {
+		return fmt.Errorf("failed to move file from %s to %s: %w", sourceAbsPath, destAbsPath, err)
+	}
+
+	return nil
+}
+
+func buildMoveCommand(cfg *Config) *cobra.Command {
+	moveCmd := &cobra.Command{
+		Use:     "move [repo_name//path/to/ttp] [repo_name//path/to/destination]",
+		Short:   "Move or rename a TTPForge TTP",
+		Long:    "Use this command to move a TTP to a new location, updating all references.",
+		Example: "ttpforge move examples//actions/inline/basic.yaml examples//actions/inline/basic-new.yaml",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			sourceTTPRef := args[0]
+			destTTPRef := args[1]
+
+			// Resolve source TTP
+			sourceRepo, sourceAbsPath, err := cfg.repoCollection.ResolveTTPRef(sourceTTPRef)
+			if err != nil {
+				return fmt.Errorf("failed to resolve source TTP reference %v: %w", sourceTTPRef, err)
+			}
+
+			sourceRef, err := cfg.repoCollection.ConvertAbsPathToAbsRef(sourceRepo, sourceAbsPath)
+			if err != nil {
+				return fmt.Errorf("failed to convert source path to reference: %w", err)
+			}
+
+			fs := afero.NewOsFs()
+
+			// Parse destination TTP reference
+			destRepo, destRef, err := cfg.repoCollection.ParseTTPRef(destTTPRef)
+			if err != nil {
+				return fmt.Errorf("failed to parse destination TTP reference: %w", err)
+			}
+
+			// If no repo specified in destination, use source repo
+			if destRepo == nil || destRepo.GetName() == "" {
+				destRepo = sourceRepo
+				// Reconstruct the destination reference with proper repo prefix
+				if !strings.Contains(destTTPRef, repos.RepoPrefixSep) {
+					destRef = sourceRepo.GetName() + repos.RepoPrefixSep + destTTPRef
+				}
+			}
+
+			// Validate destination repo exists
+			if _, err := cfg.repoCollection.GetRepo(destRepo.GetName()); err != nil {
+				return fmt.Errorf("destination repository %s not found: %w", destRepo.GetName(), err)
+			}
+
+			// Check if destination already exists
+			searchPaths := destRepo.GetTTPSearchPaths()
+			if len(searchPaths) == 0 {
+				return fmt.Errorf("no TTP search paths configured for repository %s", destRepo.GetName())
+			}
+
+			// Extract just the path part from destRef (after //)
+			destPath := destRef
+
+			if idx := strings.Index(destRef, repos.RepoPrefixSep); idx != -1 {
+				destPath = destRef[idx+2:]
+			}
+
+			for _, searchPath := range searchPaths {
+				candidatePath := filepath.Join(searchPath, destPath)
+				if exists, err := afero.Exists(fs, candidatePath); err != nil {
+					return fmt.Errorf("failed to check if destination exists: %w", err)
+				} else if exists {
+					return fmt.Errorf("destination %s already exists at %s", destTTPRef, candidatePath)
+				}
+			}
+
+			// Use first search path as destination (as documented in move.md)
+			destAbsPath := filepath.Join(searchPaths[0], destPath)
+
+			// Update all TTP references before moving the file
+			if err := findAndReplaceTTPReferences(cfg.repoCollection, fs, sourceRepo, sourceRef, destRef); err != nil {
+				return fmt.Errorf("failed to update TTP references: %w", err)
+			}
+
+			// Move the actual file
+			fmt.Printf("Moving TTP from %s to %s\n", sourceRef, destRef)
+			if err := moveFile(fs, sourceAbsPath, destAbsPath); err != nil {
+				return fmt.Errorf("failed to move file: %w", err)
+			}
+
+			fmt.Printf("Successfully moved TTP to: %s\n", destAbsPath)
+			return nil
+		},
+	}
+
+	return moveCmd
+}

--- a/cmd/move_test.go
+++ b/cmd/move_test.go
@@ -1,0 +1,456 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	workingDir = "ttpforge-move-test"
+	repoName   = "test-repo"
+	searchPath = "ttps"
+)
+
+type moveCmdTestCase struct {
+	name              string
+	description       string
+	sourceArg         string
+	destArg           string
+	wantError         bool
+	errorContains     string
+	expectedNewPath   string
+	expectedOldPath   string
+	setupFiles        []string
+	referencingFiles  map[string]string // path -> content that references the source file
+	expectUpdatedRefs map[string]string // path -> expected updated content
+}
+
+func setupMoveTestFiles(t *testing.T, fsys afero.Fs, baseDir string, files []string) {
+	for _, file := range files {
+		fullPath := filepath.Join(baseDir, file)
+		dir := filepath.Dir(fullPath)
+		err := fsys.MkdirAll(dir, 0755)
+		require.NoError(t, err)
+
+		content := `---
+name: Test TTP
+description: A test TTP for move command testing
+steps:
+  - name: test_step
+    inline: echo "test output"
+`
+		err = afero.WriteFile(fsys, fullPath, []byte(content), 0644)
+		require.NoError(t, err)
+	}
+}
+
+func setupReferencingFiles(t *testing.T, fsys afero.Fs, baseDir string, files map[string]string) {
+	for path, content := range files {
+		fullPath := filepath.Join(baseDir, path)
+		dir := filepath.Dir(fullPath)
+		err := fsys.MkdirAll(dir, 0755)
+		require.NoError(t, err)
+
+		err = afero.WriteFile(fsys, fullPath, []byte(content), 0644)
+		require.NoError(t, err)
+	}
+}
+
+func checkMoveTestCase(t *testing.T, tc moveCmdTestCase) {
+	// Create a temporary directory for this test
+	fsys := afero.NewOsFs()
+	tempDir, err := afero.TempDir(fsys, "", workingDir)
+	require.NoError(t, err)
+	defer fsys.RemoveAll(tempDir)
+
+	// Create test repository structure
+	repoDir := filepath.Join(tempDir, repoName)
+	configPath := filepath.Join(tempDir, "test-config.yaml")
+
+	// Create repo config
+	repoConfigContent := `---
+ttp_search_paths:
+  - ` + searchPath + `
+`
+	err = fsys.MkdirAll(repoDir, 0755)
+	require.NoError(t, err)
+	err = afero.WriteFile(fsys, filepath.Join(repoDir, "ttpforge-repo-config.yaml"), []byte(repoConfigContent), 0644)
+	require.NoError(t, err)
+
+	// Create main config
+	mainConfigContent := `---
+repos:
+  - name: test-repo
+    path: ` + repoDir + `
+`
+	err = afero.WriteFile(fsys, configPath, []byte(mainConfigContent), 0644)
+	require.NoError(t, err)
+
+	// Setup test files
+	if tc.setupFiles != nil {
+		setupMoveTestFiles(t, fsys, tempDir, tc.setupFiles)
+	}
+
+	// Setup referencing files
+	if tc.referencingFiles != nil {
+		setupReferencingFiles(t, fsys, tempDir, tc.referencingFiles)
+	}
+
+	// Convert reference paths to absolute paths for test repo when needed
+	sourceArg := tc.sourceArg
+	destArg := tc.destArg
+
+	// Handle test cases that use actual file paths instead of repo references
+	// This converts paths like repoName + searchPath + "basic.yaml" to absolute paths in our test repo
+	if !strings.Contains(tc.sourceArg, "//") && !filepath.IsAbs(tc.sourceArg) && tc.sourceArg != "" {
+		sourceArg = filepath.Join(tempDir, tc.sourceArg)
+	}
+	if !strings.Contains(tc.destArg, "//") && !filepath.IsAbs(tc.destArg) && tc.destArg != "" {
+		destArg = filepath.Join(tempDir, tc.destArg)
+	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	rc := BuildRootCommand(&TestConfig{
+		Stdout: &stdoutBuf,
+		Stderr: &stderrBuf,
+	})
+
+	args := []string{"move", "-c", configPath, sourceArg, destArg}
+	rc.SetArgs(args)
+
+	err = rc.Execute()
+
+	if tc.wantError {
+		require.Error(t, err)
+		if tc.errorContains != "" {
+			assert.Contains(t, err.Error(), tc.errorContains)
+		}
+		return
+	}
+
+	require.NoError(t, err, "Move command should succeed")
+
+	// Check that the file was moved to the expected location
+	if tc.expectedNewPath != "" {
+		expectedPath := filepath.Join(tempDir, tc.expectedNewPath)
+		exists, err := afero.Exists(fsys, expectedPath)
+		require.NoError(t, err)
+		assert.True(t, exists, "File should exist at new location: %s", expectedPath)
+	}
+
+	// Check that the file was removed from the old location
+	if tc.expectedOldPath != "" {
+		oldPath := filepath.Join(tempDir, tc.expectedOldPath)
+		exists, err := afero.Exists(fsys, oldPath)
+		require.NoError(t, err)
+		assert.False(t, exists, "File should not exist at old location: %s", oldPath)
+	}
+
+	// Check that referencing files were updated correctly
+	if tc.expectUpdatedRefs != nil {
+		for path, expectedContent := range tc.expectUpdatedRefs {
+			fullPath := filepath.Join(tempDir, path)
+			content, err := afero.ReadFile(fsys, fullPath)
+			require.NoError(t, err)
+			assert.Equal(t, expectedContent, string(content), "File %s should have updated references", path)
+		}
+	}
+}
+
+func TestMoveCommand(t *testing.T) {
+	testCases := []moveCmdTestCase{
+		{
+			name:        "reference-to-reference",
+			description: "Move TTP from reference path to reference path",
+			sourceArg:   repoName + "//basic.yaml",
+			destArg:     repoName + "//moved.yaml",
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+			},
+			wantError:       false,
+			expectedNewPath: filepath.Join(repoName, searchPath, "moved.yaml"),
+			expectedOldPath: filepath.Join(repoName, searchPath, "basic.yaml"),
+		},
+		{
+			name:        "reference-to-absolute",
+			description: "Move TTP from reference path to absolute path",
+			sourceArg:   repoName + "//basic.yaml",
+			destArg:     filepath.Join(repoName, searchPath, "moved.yaml"),
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+			},
+			wantError:       false,
+			expectedNewPath: filepath.Join(repoName, searchPath, "moved.yaml"),
+			expectedOldPath: filepath.Join(repoName, searchPath, "basic.yaml"),
+		},
+		{
+			name:        "absolute-to-reference",
+			description: "Move TTP from absolute path to reference path",
+			sourceArg:   filepath.Join(repoName, searchPath, "basic.yaml"),
+			destArg:     repoName + "//moved.yaml",
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+			},
+			wantError:       false,
+			expectedNewPath: filepath.Join(repoName, searchPath, "moved.yaml"),
+			expectedOldPath: filepath.Join(repoName, searchPath, "basic.yaml"),
+		},
+		{
+			name:        "absolute-to-absolute",
+			description: "Move TTP from absolute path to absolute path",
+			sourceArg:   filepath.Join(repoName, searchPath, "basic.yaml"),
+			destArg:     filepath.Join(repoName, searchPath, "moved.yaml"),
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+			},
+			wantError:       false,
+			expectedNewPath: filepath.Join(repoName, searchPath, "moved.yaml"),
+			expectedOldPath: filepath.Join(repoName, searchPath, "basic.yaml"),
+		},
+		{
+			name:        "nested-directory-move",
+			description: "Move TTP to nested directory structure",
+			sourceArg:   repoName + "//basic.yaml",
+			destArg:     repoName + "//subdir/nested/moved.yaml",
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+			},
+			wantError:       false,
+			expectedNewPath: filepath.Join(repoName, searchPath, "subdir/nested/moved.yaml"),
+			expectedOldPath: filepath.Join(repoName, searchPath, "basic.yaml"),
+		},
+		{
+			name:        "move-with-references",
+			description: "Move TTP and update references in other TTPs",
+			sourceArg:   repoName + "//basic.yaml",
+			destArg:     repoName + "//moved.yaml",
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+				filepath.Join(repoName, searchPath, "referencing.yaml"),
+			},
+			referencingFiles: map[string]string{
+				filepath.Join(repoName, searchPath, "referencing.yaml"): `---
+name: Referencing TTP
+description: A TTP that references another TTP
+steps:
+  - name: run_basic
+    ttp: ` + repoName + `//basic.yaml
+`,
+			},
+			expectUpdatedRefs: map[string]string{
+				filepath.Join(repoName, searchPath, "referencing.yaml"): `---
+name: Referencing TTP
+description: A TTP that references another TTP
+steps:
+  - name: run_basic
+    ttp: ` + repoName + `//moved.yaml
+`,
+			},
+			wantError:       false,
+			expectedNewPath: filepath.Join(repoName, searchPath, "moved.yaml"),
+			expectedOldPath: filepath.Join(repoName, searchPath, "basic.yaml"),
+		},
+		{
+			name:        "move-with-scoped-references",
+			description: "Move TTP and update scoped references (without repo prefix)",
+			sourceArg:   repoName + "//basic.yaml",
+			destArg:     repoName + "//moved.yaml",
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+				filepath.Join(repoName, searchPath, "referencing.yaml"),
+			},
+			referencingFiles: map[string]string{
+				filepath.Join(repoName, searchPath, "referencing.yaml"): `---
+name: Referencing TTP
+description: A TTP that references another TTP with scoped reference
+steps:
+  - name: run_basic
+    ttp: //basic.yaml
+`,
+			},
+			expectUpdatedRefs: map[string]string{
+				filepath.Join(repoName, searchPath, "referencing.yaml"): `---
+name: Referencing TTP
+description: A TTP that references another TTP with scoped reference
+steps:
+  - name: run_basic
+    ttp: ` + repoName + `//moved.yaml
+`,
+			},
+			wantError:       false,
+			expectedNewPath: filepath.Join(repoName, searchPath, "moved.yaml"),
+			expectedOldPath: filepath.Join(repoName, searchPath, "basic.yaml"),
+		},
+		{
+			name:        "move-with-multiple-references",
+			description: "Move TTP and update multiple references across different files",
+			sourceArg:   repoName + "//basic.yaml",
+			destArg:     repoName + "//moved.yaml",
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+				filepath.Join(repoName, searchPath, "ref1.yaml"),
+				filepath.Join(repoName, searchPath, "ref2.yaml"),
+			},
+			referencingFiles: map[string]string{
+				filepath.Join(repoName, searchPath, "ref1.yaml"): `---
+name: First Reference
+steps:
+  - name: call_basic
+    ttp: ` + repoName + `//basic.yaml
+`,
+				filepath.Join(repoName, searchPath, "ref2.yaml"): `---
+name: Second Reference
+steps:
+  - name: also_call_basic
+    ttp: //basic.yaml
+  - name: call_something_else
+    ttp: ` + repoName + `//other.yaml
+`,
+			},
+			expectUpdatedRefs: map[string]string{
+				filepath.Join(repoName, searchPath, "ref1.yaml"): `---
+name: First Reference
+steps:
+  - name: call_basic
+    ttp: ` + repoName + `//moved.yaml
+`,
+				filepath.Join(repoName, searchPath, "ref2.yaml"): `---
+name: Second Reference
+steps:
+  - name: also_call_basic
+    ttp: ` + repoName + `//moved.yaml
+  - name: call_something_else
+    ttp: ` + repoName + `//other.yaml
+`,
+			},
+			wantError:       false,
+			expectedNewPath: filepath.Join(repoName, searchPath, "moved.yaml"),
+			expectedOldPath: filepath.Join(repoName, searchPath, "basic.yaml"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			checkMoveTestCase(t, tc)
+		})
+	}
+}
+
+func TestMoveCommandEdgeCases(t *testing.T) {
+	edgeCases := []moveCmdTestCase{
+		{
+			name:          "missing-arguments",
+			description:   "Move command requires exactly 2 arguments",
+			sourceArg:     "", // Will be ignored since we're not passing any args
+			destArg:       "",
+			wantError:     true,
+			errorContains: "accepts 2 arg(s), received 0",
+		},
+		{
+			name:        "same-source-and-destination",
+			description: "Moving a file to itself should fail",
+			sourceArg:   repoName + "//basic.yaml",
+			destArg:     repoName + "//basic.yaml",
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+			},
+			wantError:     true,
+			errorContains: "already exists",
+		},
+		{
+			name:          "invalid-source-format",
+			description:   "Invalid source reference format should fail",
+			sourceArg:     "invalid//format//too//many//separators.yaml",
+			destArg:       repoName + "//moved.yaml",
+			wantError:     true,
+			errorContains: "too many occurrences",
+		},
+		{
+			name:        "invalid-dest-format",
+			description: "Invalid destination reference format should fail",
+			sourceArg:   repoName + "//basic.yaml",
+			destArg:     "invalid//format//too//many//separators.yaml",
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+			},
+			wantError:     true,
+			errorContains: "too many occurrences",
+		},
+		{
+			name:        "invalid-destination-repo",
+			description: "Moving to a non-existent repository should fail",
+			sourceArg:   repoName + "//basic.yaml",
+			destArg:     "nonexistent-repo//moved.yaml",
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+			},
+			wantError:     true,
+			errorContains: "repository 'nonexistent-repo' not found",
+		},
+		{
+			name:          "nonexistent-source",
+			description:   "Attempting to move a nonexistent TTP should fail",
+			sourceArg:     repoName + "//nonexistent.yaml",
+			destArg:       repoName + "//moved.yaml",
+			setupFiles:    []string{}, // Don't create the source file
+			wantError:     true,
+			errorContains: "failed to resolve source TTP reference",
+		},
+		{
+			name:        "destination-exists",
+			description: "Attempting to move to an existing destination should fail",
+			sourceArg:   repoName + "//basic.yaml",
+			destArg:     repoName + "//existing.yaml",
+			setupFiles: []string{
+				filepath.Join(repoName, searchPath, "basic.yaml"),
+				filepath.Join(repoName, searchPath, "existing.yaml"),
+			},
+			wantError:     true,
+			errorContains: "already exists",
+		},
+	}
+
+	for _, tc := range edgeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "missing-arguments" {
+				// Special case for missing arguments test
+				var stdoutBuf, stderrBuf bytes.Buffer
+				rc := BuildRootCommand(&TestConfig{
+					Stdout: &stdoutBuf,
+					Stderr: &stderrBuf,
+				})
+				rc.SetArgs([]string{"move"}) // No arguments
+				err := rc.Execute()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorContains)
+				return
+			}
+			checkMoveTestCase(t, tc)
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,7 @@ TTPForge is a Purple Team engagement tool to execute Tactics, Techniques, and Pr
 	rootCmd.AddCommand(buildTestCommand(cfg))
 	rootCmd.AddCommand(buildInstallCommand(cfg))
 	rootCmd.AddCommand(buildRemoveCommand(cfg))
+	rootCmd.AddCommand(buildMoveCommand(cfg))
 	rootCmd.AddCommand(buildParseYamlCommand(cfg))
 	return rootCmd
 }

--- a/docs/foundations/move.md
+++ b/docs/foundations/move.md
@@ -1,0 +1,112 @@
+# Moving TTPs
+
+## Overview
+
+The `ttpforge move` command allows you to move or rename TTP files within
+TTPForge repositories while automatically updating all references to a moved TTP.
+This ensures any files referencing a TTP work correctly after a move operation.
+
+**Note:** The `move` command does not support updating references that use
+variable substitution (e.g., `ttp: //{{.Arg.here}}/ttp.yaml`). Only static
+references are automatically updated. Be sure to manually update any dynamic
+references after moving TTPs.
+
+## Basic Usage
+
+To move a TTP, use the command shown below:
+
+```bash
+ttpforge move [source] [destination]
+```
+
+## Argument Formats
+
+The `move` command accepts source and destination arguments in several formats.
+
+**Note:** The source and destination paths should fall under a configured
+repository path, but the destination will be created if it does not exist.
+
+### 1. Repository Reference Format (Recommended)
+
+You can use repository references to specify the source and destination:
+
+```bash
+ttpforge move examples//actions/inline/basic.yaml examples//actions/inline/basic-new.yaml
+```
+
+Format: `repo_name//path/to/ttp.yaml`
+
+- `repo_name` - The name of the repository as defined in your TTPForge configuration
+- `//` - The repository separator
+- `path/to/ttp.yaml` - The path to the TTP within the repository's search paths
+
+If moving within the same repository, you can omit the `repo_name` portion.
+
+### 2. Absolute Path Format
+
+You can specify the full absolute path to TTP files on your filesystem:
+
+```bash
+ttpforge move /home/user/repo/ttps/basic.yaml /home/user/repo/ttps/basic-new.yaml
+```
+
+### 3. Mixed Format Support
+
+You can mix and match formats between source and destination:
+
+```bash
+# Repository reference to absolute path
+ttpforge move examples//basic.yaml /home/user/repo/ttps/moved.yaml
+
+# Absolute path to repository reference
+ttpforge move /home/user/repo/ttps/basic.yaml examples//moved.yaml
+```
+
+## Default Output Location
+
+**Important**: When moving to a repository using the repository
+reference format (`repo//path`), the TTP will be placed in the
+**first path** defined in that repository's `ttpforge-repo-config.yaml` file.
+
+For example, if your repository configuration contains:
+
+```yaml
+ttp_search_paths:
+  - ttps
+  - templates
+  - examples
+```
+
+A move to `myrepo//basic.yaml` places the file at `<repo_root>/ttps/basic.yaml`.
+
+## Examples
+
+### Basic Move Within Repository
+
+```bash
+ttpforge move examples//basic.yaml examples//basic-renamed.yaml
+```
+
+### Move to Nested Directory
+
+```bash
+ttpforge move examples//basic.yaml examples//actions/basic/renamed.yaml
+```
+
+### Cross-Repository Move
+
+```bash
+ttpforge move examples//basic.yaml forgearmory//imported/basic.yaml
+```
+
+### Mixed Format Move
+
+```bash
+ttpforge move examples//basic.yaml /home/user/myrepo/ttps/basic.yaml
+```
+
+### Using Absolute Paths
+
+```bash
+ttpforge move /home/user/repo/ttps/old.yaml /home/user/repo/ttps/new.yaml
+```

--- a/pkg/repos/repo.go
+++ b/pkg/repos/repo.go
@@ -68,6 +68,8 @@ type Repo interface {
 	GetFs() afero.Fs
 	GetName() string
 	GetFullPath() string
+	GetTTPSearchPaths() []string
+	GetTemplateSearchPaths() []string
 }
 
 // Config contains all the fields
@@ -81,6 +83,24 @@ type repo struct {
 	spec                Spec
 	TTPSearchPaths      []string `yaml:"ttp_search_paths"`
 	TemplateSearchPaths []string `yaml:"template_search_paths"`
+}
+
+// GetTTPSearchPaths returns the absolute paths of all configured TTP search directories
+func (r *repo) GetTTPSearchPaths() []string {
+	absPaths := make([]string, len(r.TTPSearchPaths))
+	for i, path := range r.TTPSearchPaths {
+		absPaths[i] = filepath.Join(r.fullPath, path)
+	}
+	return absPaths
+}
+
+// GetTemplateSearchPaths returns the absolute paths of all configured template search directories
+func (r *repo) GetTemplateSearchPaths() []string {
+	absPaths := make([]string, len(r.TemplateSearchPaths))
+	for i, path := range r.TemplateSearchPaths {
+		absPaths[i] = filepath.Join(r.fullPath, path)
+	}
+	return absPaths
 }
 
 // ListsTTPs lists the TTPs in this repo


### PR DESCRIPTION
# Overview
This diff introduces a `move` command to TTPForge. This command enables you to move forge files while keeping any subttp references intact.

# Context
This implementation spawned from a growing need for reorganization within the growing list of available forges.

# Future Improvements
Currently, regex pattern matching is used to find and update existing references. Aditional testing should be done to confirm that the regex patterns being tested only update the appropriate references. Additional handling could be added for partial path matches in cases were paths are dynamically generated based on variable values.

When specifying a reference path for the destination (repo//path/to/ttp), the current implementation uses the repository's first search path to store the file. This could be improved to look through all of the search paths and find one that is the closest to the provided path.

# Changes
- Added `move` command to the root command.
- `move.go` and `move_test.go` hold implementation and testing for the `move` command respectively.
- Separated TTPRef parsing out from TTPRef resolution in `repocollection.go`.
- Updated `AbsPath()` in `fileutils.go` to resolve the actual absolute path following any symlinks.

Reviewed By: RoboticPrism

Differential Revision: D80826527