### PR TITLE
TTPForge Move Command Reference Update

### DIFF
--- a/docs/foundations/move.md
+++ b/docs/foundations/move.md
@@ -19,6 +19,24 @@ To move a TTP, use the command shown below:
 ttpforge move [source] [destination]
 ```
 
+## Cross-Repository Moves
+
+You can move TTPs between repositories by specifying the source and destination.
+For example, to move a TTP from the `examples` repository to the `forgearmory`
+repository, you can use the following command:
+
+```bash
+ttpforge move examples//basic.yaml forgearmory//imported/basic.yaml
+```
+
+Any TTP files that reference a moved TTP will be updated to point to its new
+location using relative references they are within the same repository, or
+absolute references if they are in different repositories.
+
+**Note:** These repository names are defined in your TTPForge configuration
+file, so take caution when performing cross-repository moves as your config file
+may not match the config files of other users.
+
 ## Argument Formats
 
 The `move` command accepts source and destination arguments in several formats.


### PR DESCRIPTION
Summary:
Updated TTPForge Move command to consider the destination repository when performing the move.

Now updates files to reference `//path/to/ttp.yaml` for the new subTTP path instead of `repo//path/to/ttp.yaml` by default.

If the destination repo is different than the repo the file is in, a repository name will be provided based off the one in the config. **This has the potential to create inconsistencies in name resolution as different users may have different mappings from the standard ones in the config file.**

Updated documentation to discuss this change and provide a warning for cross-repository moves.

Reviewed By: samdlinn

Differential Revision: D81613044


