### PR TITLE
TTPForge Enum Dependencies Command

### DIFF
--- a/cmd/enum.go
+++ b/cmd/enum.go
@@ -31,5 +31,6 @@ func buildEnumCommand(cfg *Config) *cobra.Command {
 		TraverseChildren: true,
 	}
 	enumCmd.AddCommand(buildEnumTTPsCommand(cfg))
+	enumCmd.AddCommand(buildEnumDependenciesCommand(cfg))
 	return enumCmd
 }

--- a/cmd/enumdependencies.go
+++ b/cmd/enumdependencies.go
@@ -1,0 +1,143 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/facebookincubator/ttpforge/pkg/repos"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"regexp"
+	"strings"
+)
+
+func findTTPReferences(rc repos.RepoCollection, fs afero.Fs, sourceRef string) ([]string, error) {
+	var matchList []string
+
+	// Parse source reference
+	index := strings.Index(sourceRef, repos.RepoPrefixSep)
+	if index == -1 {
+		return nil, fmt.Errorf("invalid source reference format: %s", sourceRef)
+	}
+
+	sourceRepo := sourceRef[:index]
+	sourceScopedRef := sourceRef[index:]
+	sourceBareRef := sourceRef[index+2:]
+
+	// Build patterns for finding references in ttp: YAML fields:
+	// 1. Full reference: ttp: examples//actions/inline/basic.yaml
+	// 2. Scoped reference: ttp: //actions/inline/basic.yaml
+	// 3. Bare reference: ttp: actions/inline/basic.yaml (legacy compatibility)
+	// These patterns match the entire ttp: field value including any surrounding whitespace
+	fullRefPattern := regexp.MustCompile(`(\s*ttp:\s*)` + regexp.QuoteMeta(sourceRef) + `(\s*)`)
+	scopedRefPattern := regexp.MustCompile(`(\s*ttp:\s*)` + regexp.QuoteMeta(sourceScopedRef) + `(\s*)`)
+	bareRefPattern := regexp.MustCompile(`(\s*ttp:\s*)` + regexp.QuoteMeta(sourceBareRef) + `(\s*)`)
+
+	ttpRefs, err := rc.ListTTPs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list TTPs: %w", err)
+	}
+
+	for _, ttpRef := range ttpRefs {
+		repo, ttpAbsPath, err := rc.ResolveTTPRef(ttpRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve TTP reference %v: %w", ttpRef, err)
+		}
+
+		content, err := afero.ReadFile(fs, ttpAbsPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read TTP %v: %w", ttpRef, err)
+		}
+
+		// Priority 1: Full reference match (examples//actions/inline/basic.yaml)
+		if fullRefPattern.Match(content) {
+			// add to storage
+			matchList = append(matchList, ttpRef)
+		} else if repo.GetName() == sourceRepo {
+			// Priority 2: Scoped reference match (//actions/inline/basic.yaml)
+			if scopedRefPattern.Match(content) {
+				matchList = append(matchList, ttpRef)
+			} else if bareRefPattern.Match(content) {
+				// Priority 3: Bare reference match (actions/inline/basic.yaml) - legacy compatibility
+				matchList = append(matchList, ttpRef)
+			}
+		}
+	}
+
+	return matchList, nil
+}
+
+func buildEnumDependenciesCommand(cfg *Config) *cobra.Command {
+	enumDependenciesCmd := &cobra.Command{
+		Use:     "dependencies [repo_name//path/to/ttp]",
+		Short:   "Enumerate TTPs that depend on a given TTP",
+		Long:    "Use this command to enumerate TTPs that depend on a given TTP",
+		Example: "ttpforge enum dependencies examples//actions/inline/basic.yaml ",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Don't want confusing usage display for errors past this point
+			cmd.SilenceUsage = true
+
+			sourceTTPRef := args[0]
+
+			// Resolve source TTP
+			sourceRepo, sourceAbsPath, err := cfg.repoCollection.ResolveTTPRef(sourceTTPRef)
+			if err != nil {
+				return fmt.Errorf("failed to resolve source TTP reference %v: %w", sourceTTPRef, err)
+			}
+
+			// If the repo is not defined in the config file, add it to the collection to resolve references
+			if _, err := cfg.repoCollection.GetRepo(sourceRepo.GetName()); err != nil {
+				if err := cfg.repoCollection.AddRepo(sourceRepo); err != nil {
+					return err
+				}
+			}
+
+			sourceRef, err := cfg.repoCollection.ConvertAbsPathToAbsRef(sourceRepo, sourceAbsPath)
+			if err != nil {
+				return fmt.Errorf("failed to convert source path to reference: %w", err)
+			}
+
+			fs := afero.NewOsFs()
+
+			matches, err := findTTPReferences(cfg.repoCollection, fs, sourceRef)
+			if err != nil {
+				return err
+			}
+
+			if matches != nil {
+				fmt.Printf("Total dependencies found: %d\n", len(matches))
+
+				if logConfig.Verbose {
+					fmt.Println("Dependencies found: ")
+					for _, match := range matches {
+						fmt.Printf("\t%s\n", match)
+					}
+				}
+			} else {
+				fmt.Printf("No dependencies found\n")
+			}
+
+			return nil
+		},
+	}
+
+	return enumDependenciesCmd
+}

--- a/cmd/enumdependencies_test.go
+++ b/cmd/enumdependencies_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	enumDepsWorkingDir  = "ttpforge-enumdeps-test"
+	enumDepsPrimaryRepo = "test-repo"
+	enumDepsSearchPath  = "ttps"
+)
+
+type enumDepsCmdTestCase struct {
+	name             string
+	description      string
+	sourceArg        string
+	wantError        bool
+	errorContains    string
+	setupFiles       []string
+	referencingFiles map[string]string // path -> content that references the source file
+	verbose          bool
+}
+
+func setupEnumDepsTestFiles(t *testing.T, fsys afero.Fs, baseDir string, files []string) {
+	for _, file := range files {
+		fullPath := filepath.Join(baseDir, file)
+		dir := filepath.Dir(fullPath)
+		err := fsys.MkdirAll(dir, 0755)
+		require.NoError(t, err)
+
+		content := `---
+name: Test TTP
+description: A test TTP for enum dependencies testing
+steps:
+  - name: test_step
+    inline: echo "test output"
+`
+		err = afero.WriteFile(fsys, fullPath, []byte(content), 0644)
+		require.NoError(t, err)
+	}
+}
+
+func setupEnumDepsReferencingFiles(t *testing.T, fsys afero.Fs, baseDir string, files map[string]string) {
+	for path, content := range files {
+		fullPath := filepath.Join(baseDir, path)
+		dir := filepath.Dir(fullPath)
+		err := fsys.MkdirAll(dir, 0755)
+		require.NoError(t, err)
+
+		err = afero.WriteFile(fsys, fullPath, []byte(content), 0644)
+		require.NoError(t, err)
+	}
+}
+
+func checkEnumDepsTestCase(t *testing.T, tc enumDepsCmdTestCase) {
+	// Create a temporary directory for this test
+	fsys := afero.NewOsFs()
+	tempDir, err := afero.TempDir(fsys, "", enumDepsWorkingDir)
+	require.NoError(t, err)
+	defer fsys.RemoveAll(tempDir)
+
+	// Create test repository structure
+	primaryRepoDir := filepath.Join(tempDir, enumDepsPrimaryRepo)
+	configPath := filepath.Join(tempDir, "test-config.yaml")
+
+	// Create repo config
+	repoConfigContent := `---
+ttp_search_paths:
+  - ` + enumDepsSearchPath + `
+`
+	err = fsys.MkdirAll(filepath.Join(primaryRepoDir, enumDepsSearchPath), 0755)
+	require.NoError(t, err)
+	err = afero.WriteFile(fsys, filepath.Join(primaryRepoDir, "ttpforge-repo-config.yaml"), []byte(repoConfigContent), 0644)
+	require.NoError(t, err)
+
+	// Create main config
+	mainConfigContent := `---
+repos:
+  - name: ` + enumDepsPrimaryRepo + `
+    path: ` + primaryRepoDir + `
+`
+	err = afero.WriteFile(fsys, configPath, []byte(mainConfigContent), 0644)
+	require.NoError(t, err)
+
+	// Setup test files
+	if tc.setupFiles != nil {
+		setupEnumDepsTestFiles(t, fsys, tempDir, tc.setupFiles)
+	}
+
+	// Setup referencing files
+	if tc.referencingFiles != nil {
+		setupEnumDepsReferencingFiles(t, fsys, tempDir, tc.referencingFiles)
+	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	rc := BuildRootCommand(&TestConfig{
+		Stdout: &stdoutBuf,
+		Stderr: &stderrBuf,
+	})
+
+	args := []string{"enum", "dependencies", "-c", configPath, tc.sourceArg}
+	if tc.verbose {
+		args = append(args, "--verbose")
+	}
+	rc.SetArgs(args)
+
+	err = rc.Execute()
+
+	if tc.wantError {
+		require.Error(t, err)
+		if tc.errorContains != "" {
+			assert.Contains(t, err.Error(), tc.errorContains)
+		}
+		return
+	}
+
+	require.NoError(t, err, "Enum dependencies command should succeed")
+}
+
+func TestEnumDependenciesCommand(t *testing.T) {
+	testCases := []enumDepsCmdTestCase{
+		{
+			name:        "dependency-count-1",
+			description: "Find exactly 1 dependency with verbose output",
+			sourceArg:   enumDepsPrimaryRepo + "//basic.yaml",
+			setupFiles: []string{
+				filepath.Join(enumDepsPrimaryRepo, enumDepsSearchPath, "basic.yaml"),
+				filepath.Join(enumDepsPrimaryRepo, enumDepsSearchPath, "referencing.yaml"),
+			},
+			referencingFiles: map[string]string{
+				filepath.Join(enumDepsPrimaryRepo, enumDepsSearchPath, "referencing.yaml"): `---
+name: Referencing TTP
+description: A TTP that references basic.yaml
+steps:
+  - name: call_basic
+    ttp: ` + enumDepsPrimaryRepo + `//basic.yaml
+`,
+			},
+			verbose:   true,
+			wantError: false,
+		},
+		{
+			name:        "dependency-count-0",
+			description: "Find no dependencies with verbose output",
+			sourceArg:   enumDepsPrimaryRepo + "//standalone.yaml",
+			setupFiles: []string{
+				filepath.Join(enumDepsPrimaryRepo, enumDepsSearchPath, "standalone.yaml"),
+				filepath.Join(enumDepsPrimaryRepo, enumDepsSearchPath, "other.yaml"),
+			},
+			referencingFiles: map[string]string{
+				filepath.Join(enumDepsPrimaryRepo, enumDepsSearchPath, "other.yaml"): `---
+name: Other TTP
+description: Does not reference standalone
+steps:
+  - name: test_step
+    inline: echo "no reference"
+`,
+			},
+			verbose:   true,
+			wantError: false,
+		},
+		{
+			name:          "nonexistent-ttp",
+			description:   "Attempting to enum dependencies for nonexistent TTP should fail",
+			sourceArg:     enumDepsPrimaryRepo + "//nonexistent.yaml",
+			setupFiles:    []string{}, // Don't create the source file
+			wantError:     true,
+			errorContains: "failed to resolve source TTP reference",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			checkEnumDepsTestCase(t, tc)
+		})
+	}
+}

--- a/docs/foundations/enum.md
+++ b/docs/foundations/enum.md
@@ -1,6 +1,6 @@
 # Enumeration
 
-## Enumerating TTPs of platforms in a repo
+## Enumerating TTPs Based on Provided Filters
 
 To enumerate the TTPs in a repo, use the command shown below:
 
@@ -18,3 +18,13 @@ TTPForge will be able to find and enumerate all TTPs in the config file.
 
 The output is a platform-wise count of TTPs in the repo along with other
 information like total count and total match count after applying filters.
+
+## Enumerating TTP Dependencies
+
+To enumerate the dependencies of a TTP, use the command shown below:
+
+```bash
+ttpforge enum dependencies [repo_name//path/to/ttp] --verbose
+```
+
+The output lists all dependencies that rely on the TTP as well as a total count.


### PR DESCRIPTION
Summary:
# Overview
This diff introduces an addition to the `enum` command `enum dependencies` that will enumerate all TTPs that use a given TTP as a subTTP step.

# Context
This implementation spawned from a need to identify dependencies within the growing list of available forges.

# Future Improvements
The testing suite sets up several possible scenarios, but it could be improved by confirming command output matches what's expected. This should be made easier if all modules migrate to the internal logging package.

# Changes
- Added `dependencies` subcommand to the `enum` command.
- `enumdependencies.go` and `enumdependencies_test.go` hold implementation and testing for the `enum dependencies` command respectively.

Reviewed By: RoboticPrism

Differential Revision: D82462426


