### PR TITLE
TTPForge Remove TTP Command

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -26,10 +26,11 @@ import (
 func buildRemoveCommand(cfg *Config) *cobra.Command {
 	removeCmd := &cobra.Command{
 		Use:              "remove",
-		Short:            "remove (uninstall) various types of resources used by TTPForge",
-		Long:             "For now, you just want to use the 'ttpforge remove repo' subcommand",
+		Short:            "remove (uninstall/delete) various types of resources used by TTPForge",
+		Long:             "Use this command to remove repos, TTPs, etc.",
 		TraverseChildren: true,
 	}
 	removeCmd.AddCommand(buildRemoveRepoCommand(cfg))
+	removeCmd.AddCommand(buildRemoveTTPCommand(cfg))
 	return removeCmd
 }

--- a/cmd/removettp.go
+++ b/cmd/removettp.go
@@ -1,0 +1,92 @@
+/*
+Copyright © 2023-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func buildRemoveTTPCommand(cfg *Config) *cobra.Command {
+	var unsafe bool
+
+	removeTTPCommand := &cobra.Command{
+		Use:              "ttp [repo_name//path/to/ttp]",
+		Short:            "remove a TTP used by TTPForge",
+		TraverseChildren: true,
+		Args:             cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Don't want confusing usage display for errors past this point
+			cmd.SilenceUsage = true
+
+			sourceTTPRef := args[0]
+
+			// Resolve source TTP
+			sourceRepo, sourceAbsPath, err := cfg.repoCollection.ResolveTTPRef(sourceTTPRef)
+			if err != nil {
+				return fmt.Errorf("failed to resolve source TTP reference %v: %w", sourceTTPRef, err)
+			}
+
+			// If the repo is not defined in the config file, add it to the collection to resolve references
+			if _, err := cfg.repoCollection.GetRepo(sourceRepo.GetName()); err != nil {
+				if err := cfg.repoCollection.AddRepo(sourceRepo); err != nil {
+					return err
+				}
+			}
+
+			sourceRef, err := cfg.repoCollection.ConvertAbsPathToAbsRef(sourceRepo, sourceAbsPath)
+			if err != nil {
+				return fmt.Errorf("failed to convert source path to reference: %w", err)
+			}
+
+			fs := afero.NewOsFs()
+
+			if !unsafe {
+				// Gather references of files that use this TTP as a dependency
+				matches, err := findTTPReferences(cfg.repoCollection, fs, sourceRef)
+				if err != nil {
+					return err
+				}
+
+				if matches != nil {
+					for _, match := range matches {
+						fmt.Printf("Dependency at %s\n", match)
+					}
+					fmt.Println("Ending early - review these dependencies before deletion")
+					return nil
+				}
+			}
+
+			fmt.Printf("Removing TTP %s\n", sourceRef)
+			if err := fs.Remove(sourceAbsPath); err != nil {
+				return fmt.Errorf("failed to remove file: %w", err)
+			}
+
+			fmt.Printf("Successfully removed %s\n", sourceAbsPath)
+
+			return nil
+		},
+	}
+
+	removeTTPCommand.PersistentFlags().BoolVar(&unsafe, "unsafe", false, "Skip dependency check and perform unsafe deletion")
+
+	return removeTTPCommand
+}

--- a/docs/foundations/remove.md
+++ b/docs/foundations/remove.md
@@ -1,0 +1,48 @@
+# Removing TTPs and Repositories
+
+## Overview
+
+The `ttpforge remove` command allows you to remove TTPs and repositories from
+TTPForge. This command provides two subcommands:
+
+1. `repo` for removing entire repositories and their associated configuration
+2. `ttp` for removing individual TTP files with automatic dependency checking
+
+## Remove a Repository
+
+To remove an entire repository:
+
+```bash
+ttpforge remove repo [repo_name]
+```
+
+When removing a repository, TTPForge will locate the repository by name in your
+configuration, delete all files in its file system path, remove the repository
+entry from your TTPForge configuration file, and save the updated configuration.
+
+**Warning:** Repository removal is irreversible. Ensure you have backups of any
+important TTPs before removing a repository.
+
+## Remove a TTP
+
+To remove a specific TTP file:
+
+```bash
+ttpforge remove ttp [repo_name//path/to/ttp]
+```
+
+If dependencies are found, the command will list all files that reference the
+TTP and exit without deleting it. This prevents accidental removal of TTPs that
+are still in use.
+
+### Unsafe Removal
+
+Use the `--unsafe` flag to skip dependency checking and force deletion:
+
+```bash
+ttpforge remove ttp --unsafe examples//basic.yaml
+```
+
+**Warning:** Using `--unsafe` can break other TTPs that depend on the
+removed TTP. Only use this flag when you're certain no other TTPs
+depend on the target file.


### PR DESCRIPTION
Summary:
# Overview
This diff introduces an addition to the `remove` command `remove ttp` that will safely remove a TTP file by checking for dependencies before removal.

# Context
This implementation spawned from a need to identify dependencies when managing files within the growing list of available forges.

# Future Improvements
A basic test suite could be added to confirm that files are being removed appropriately with the expected output. This will be made easier with the internal logging package.

# Changes
- Added `ttp` subcommand to the `remove` command in `removettp.go`.
- Added `remove.md` documenting the remove command and its subcommands.

Reviewed By: RoboticPrism

Differential Revision: D82462428


