### PR TITLE
fix: close file handle in CreateFileStep

### DIFF
--- a/pkg/blocks/createfile.go
+++ b/pkg/blocks/createfile.go
@@ -129,6 +129,7 @@ func (s *CreateFileStep) Execute(_ TTPExecutionContext) (*ActResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	_, err = f.Write([]byte(s.Contents))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Proposed Changes

Fixes #556

Add missing `defer f.Close()` to properly release file handles after creating files.

## Related Issue(s)

#556 
