### PR TITLE
TTPForge: Enable StepVars in Own Cleanup Action

### DIFF
--- a/example-ttps/cleanup/stepvars.yaml
+++ b/example-ttps/cleanup/stepvars.yaml
@@ -1,0 +1,16 @@
+---
+api_version: 2.0
+uuid: c3a8633c-effd-493d-8ed2-e0910d508dd6
+name: Cleanup Demonstration With StepVars
+description: |
+  This TTP demonstrates how to use step variables to pass data between steps, including in the cleanup action.
+steps:
+  - name: step
+    description: Create a random number between 0 and 100
+    inline: |
+      # Create a variable in this step
+      echo $((RANDOM%100))
+    outputvar: output
+    cleanup:
+      inline: |
+        echo "Here is the variable created above: {[{.StepVars.output}]}"

--- a/pkg/blocks/step.go
+++ b/pkg/blocks/step.go
@@ -166,15 +166,10 @@ func (s *Step) Validate(execCtx TTPExecutionContext) error {
 	return nil
 }
 
-// Template replaces variables in the step action and cleanup
+// Template replaces variables in the step action
 func (s *Step) Template(execCtx TTPExecutionContext) error {
 	if err := s.action.Template(execCtx); err != nil {
 		return err
-	}
-	if s.cleanup != nil {
-		if err := s.cleanup.Template(execCtx); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -203,6 +198,9 @@ func (s *Step) Cleanup(execCtx TTPExecutionContext) (*ActResult, error) {
 		desc := s.cleanup.GetDescription()
 		if desc != "" {
 			logging.L().Infof("Description: %v", desc)
+		}
+		if err := s.cleanup.Template(execCtx); err != nil {
+			return nil, err
 		}
 		return s.cleanup.Execute(execCtx)
 	}

--- a/pkg/blocks/step_test.go
+++ b/pkg/blocks/step_test.go
@@ -136,14 +136,15 @@ cleanup:
 			wantTemplateError: true,
 		},
 		{
-			name: "Errors on missing variable in cleanup templating",
+			name: "Errors on missing variable in cleanup templating at cleanup time",
 			content: `
 name: template_step
 inline: echo "this is a run"
 cleanup:
   inline: echo {[{.StepVars.cleanup_message}]}
 `,
-			wantTemplateError: true,
+			expectedExecuteStdout: "this is a run\n",
+			wantCleanupError:      true,
 		},
 	}
 


### PR DESCRIPTION
Summary:
Currently, StepVars can only be used in actions after the action they are created in.  This is also true of cleanup actions, meaning that you cannot use a StepVar generated in an action in that actions own cleanup.

By by waiting to do templating until we're at cleanup time, we can allow a StepVar created in a step to be available within its own cleanup action.

An example of where this could be useful could be a TTP that calls an API to create a new user and recieves a dynamically created new user id.  Now we can get the user id in the action, and then pass the  user id into the cleanup step to call a user deletion API.

Reviewed By: d0n601

Differential Revision: D83680470


