### PR TITLE
Enable Empty Default String Argument (#612)

### DIFF
--- a/pkg/args/choices_test.go
+++ b/pkg/args/choices_test.go
@@ -48,7 +48,7 @@ func TestValidateArgsChoices(t *testing.T) {
 				{
 					Name:    "alpha",
 					Choices: []string{"foo", "bar"},
-					Default: "baz",
+					Default: StringPtr("baz"),
 				},
 			},
 			argKvStrs: []string{

--- a/pkg/args/spec.go
+++ b/pkg/args/spec.go
@@ -34,11 +34,19 @@ import (
 type Spec struct {
 	Name    string   `yaml:"name"`
 	Type    string   `yaml:"type,omitempty"`
-	Default string   `yaml:"default,omitempty"`
+	Default *string  `yaml:"default,omitempty"`
 	Choices []string `yaml:"choices,omitempty"`
 	Format  string   `yaml:"regexp,omitempty"`
 
 	formatReg *regexp.Regexp
+}
+
+// StringPtr is a helper to create a *string from a string literal.
+// Useful for setting Default values in Spec definitions and tests.
+//
+//nolint:modernize // auto-fix produces invalid syntax for this pattern
+func StringPtr(s string) *string {
+	return &s
 }
 
 // ParseAndValidate checks that the provided arguments
@@ -71,16 +79,17 @@ func ParseAndValidate(specs []Spec, argsKvStrs []string, cliBaseDir string, defa
 
 		// set the default value, will be overwritten by passed value
 		// Path defaults are resolved relative to defaultBaseDir (typically the YAML directory)
-		if spec.Default != "" {
-			if !spec.isValidChoice(spec.Default) {
-				return nil, fmt.Errorf("invalid default value: %v, allowed values: %v ", spec.Default, strings.Join(spec.Choices, ", "))
+		if spec.Default != nil {
+			defaultStr := *spec.Default
+			if !spec.isValidChoice(defaultStr) {
+				return nil, fmt.Errorf("invalid default value: %v, allowed values: %v ", defaultStr, strings.Join(spec.Choices, ", "))
 			}
 
 			// For path types, resolve relative paths relative to defaultBaseDir
 			// Absolute paths and paths with shell variables are left as-is
-			defaultValue := spec.Default
-			if spec.Type == "path" && !filepath.IsAbs(spec.Default) && !fileutils.ContainsShellVariable(spec.Default) {
-				defaultValue = filepath.Join(defaultBaseDir, spec.Default)
+			defaultValue := defaultStr
+			if spec.Type == "path" && !filepath.IsAbs(defaultStr) && !fileutils.ContainsShellVariable(defaultStr) {
+				defaultValue = filepath.Join(defaultBaseDir, defaultStr)
 			}
 
 			defaultVal, err := spec.convertArgToType(defaultValue)

--- a/pkg/args/spec_test.go
+++ b/pkg/args/spec_test.go
@@ -80,7 +80,7 @@ func TestValidateArgs(t *testing.T) {
 				{
 					Name:    "beta",
 					Type:    "int",
-					Default: "1337",
+					Default: StringPtr("1337"),
 				},
 			},
 			argKvStrs: []string{
@@ -197,13 +197,43 @@ func TestValidateArgs(t *testing.T) {
 				{
 					Name:    "alpha",
 					Type:    "int",
-					Default: "wut",
+					Default: StringPtr("wut"),
 				},
 			},
 			argKvStrs: []string{
 				"alpha=1337",
 			},
 			wantError: true,
+		},
+		{
+			name: "Empty String Default Is Valid (Not Required)",
+			specs: []Spec{
+				{
+					Name:    "alpha",
+					Default: StringPtr(""),
+				},
+			},
+			argKvStrs: []string{},
+			expectedResult: map[string]any{
+				"alpha": "",
+			},
+			wantError: false,
+		},
+		{
+			name: "Empty String Default Can Be Overridden",
+			specs: []Spec{
+				{
+					Name:    "alpha",
+					Default: StringPtr(""),
+				},
+			},
+			argKvStrs: []string{
+				"alpha=override",
+			},
+			expectedResult: map[string]any{
+				"alpha": "override",
+			},
+			wantError: false,
 		},
 		{
 			name: "Format with valid value",
@@ -344,7 +374,7 @@ func TestPathArgHandling(t *testing.T) {
 				{
 					Name:    "file",
 					Type:    "path",
-					Default: "yaml-file.txt",
+					Default: StringPtr("yaml-file.txt"),
 				},
 			},
 			argKvStrs:      []string{},
@@ -379,7 +409,7 @@ func TestPathArgHandling(t *testing.T) {
 				{
 					Name:    "file",
 					Type:    "path",
-					Default: cliFile,
+					Default: StringPtr(cliFile),
 				},
 			},
 			argKvStrs:      []string{},
@@ -414,7 +444,7 @@ func TestPathArgHandling(t *testing.T) {
 				{
 					Name:    "file",
 					Type:    "path",
-					Default: "./yaml-file.txt",
+					Default: StringPtr("./yaml-file.txt"),
 				},
 			},
 			argKvStrs:      []string{},
@@ -449,7 +479,7 @@ func TestPathArgHandling(t *testing.T) {
 				{
 					Name:    "file",
 					Type:    "path",
-					Default: "../cli/cli-file.txt",
+					Default: StringPtr("../cli/cli-file.txt"),
 				},
 			},
 			argKvStrs:      []string{},
@@ -484,7 +514,7 @@ func TestPathArgHandling(t *testing.T) {
 				{
 					Name:    "file",
 					Type:    "path",
-					Default: "yaml-file.txt",
+					Default: StringPtr("yaml-file.txt"),
 				},
 			},
 			argKvStrs: []string{
@@ -503,7 +533,7 @@ func TestPathArgHandling(t *testing.T) {
 				{
 					Name:    "default_file",
 					Type:    "path",
-					Default: "yaml-file.txt",
+					Default: StringPtr("yaml-file.txt"),
 				},
 				{
 					Name: "cli_file",


### PR DESCRIPTION
Summary:

Previously, default string arguments of "" were not accepted as valid arguments. This meant that you needed to use a placeholder value and add handling for that specific value in order to have 'optional' arguments.

To fix this, the string argument type is now a reference which enables us to distinguish between no argument and an empty string.

Reviewed By: RoboticPrism

Differential Revision: D100171959


