### PR TITLE
Wire up TTP-level env to inject into all steps

### DIFF
--- a/pkg/blocks/context.go
+++ b/pkg/blocks/context.go
@@ -60,6 +60,7 @@ type TTPExecutionVars struct {
 type TTPExecutionContext struct {
 	Cfg               TTPExecutionConfig
 	Vars              *TTPExecutionVars
+	GlobalEnv         map[string]string
 	StepResults       *StepResultsRecord
 	Backend           backends.ExecutionBackend
 	ConnPool          *backends.ConnectionPool

--- a/pkg/blocks/executor.go
+++ b/pkg/blocks/executor.go
@@ -130,8 +130,9 @@ func (e *ScriptExecutor) Execute(ctx context.Context, execCtx TTPExecutionContex
 
 	// Remote backend path: delegate to backend.RunCommand
 	if execCtx.Backend != nil {
-		// For remote execution, only pass explicitly declared env vars
-		expandedEnvAsList, err := execCtx.ExpandVariables(FetchEnv(e.Environment))
+		// For remote execution, pass TTP-level env + step env (no os.Environ)
+		envAsList := append(FetchEnv(execCtx.GlobalEnv), FetchEnv(e.Environment)...)
+		expandedEnvAsList, err := execCtx.ExpandVariables(envAsList)
 		if err != nil {
 			return nil, err
 		}
@@ -153,8 +154,9 @@ func (e *ScriptExecutor) Execute(ctx context.Context, execCtx TTPExecutionContex
 		logging.L().Debugw("executor found in path", "executor", e.Name)
 	}
 
-	// expand variables in environment (include inherited env for local execution)
-	envAsList := append(FetchEnv(e.Environment), os.Environ()...)
+	// Build environment: inherited → TTP-level → step-level (last wins)
+	envAsList := append(os.Environ(), FetchEnv(execCtx.GlobalEnv)...)
+	envAsList = append(envAsList, FetchEnv(e.Environment)...)
 	expandedEnvAsList, err := execCtx.ExpandVariables(envAsList)
 	if err != nil {
 		return nil, err
@@ -178,7 +180,9 @@ func (e *FileExecutor) Execute(ctx context.Context, execCtx TTPExecutionContext)
 
 	// Remote backend path: delegate to backend.RunCommand
 	if execCtx.Backend != nil {
-		expandedEnvAsList, err := execCtx.ExpandVariables(FetchEnv(e.Environment))
+		// For remote execution, pass TTP-level env + step env (no os.Environ)
+		envAsList := append(FetchEnv(execCtx.GlobalEnv), FetchEnv(e.Environment)...)
+		expandedEnvAsList, err := execCtx.ExpandVariables(envAsList)
 		if err != nil {
 			return nil, err
 		}
@@ -210,8 +214,9 @@ func (e *FileExecutor) Execute(ctx context.Context, execCtx TTPExecutionContext)
 		logging.L().Debugw("executor found in path", "executor", e.Name)
 	}
 
-	// expand variables in environment (include inherited env for local execution)
-	envAsList := append(FetchEnv(e.Environment), os.Environ()...)
+	// Build environment: inherited → TTP-level → step-level (last wins)
+	envAsList := append(os.Environ(), FetchEnv(execCtx.GlobalEnv)...)
+	envAsList = append(envAsList, FetchEnv(e.Environment)...)
 	expandedEnvAsList, err := execCtx.ExpandVariables(envAsList)
 	if err != nil {
 		return nil, err

--- a/pkg/blocks/expectstep.go
+++ b/pkg/blocks/expectstep.go
@@ -218,11 +218,15 @@ func (s *ExpectStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 		logging.L().Warnf("failed to set terminal width: %v", err)
 	}
 
-	if s.Environment != nil {
-		for k, v := range s.Environment {
-			if err := os.Setenv(k, v); err != nil {
-				return nil, fmt.Errorf("failed to set environment variable: %w", err)
-			}
+	// Set TTP-level env vars first, then step-level (step overrides TTP)
+	for k, v := range execCtx.GlobalEnv {
+		if err := os.Setenv(k, v); err != nil {
+			return nil, fmt.Errorf("failed to set environment variable: %w", err)
+		}
+	}
+	for k, v := range s.Environment {
+		if err := os.Setenv(k, v); err != nil {
+			return nil, fmt.Errorf("failed to set environment variable: %w", err)
 		}
 	}
 

--- a/pkg/blocks/ttps.go
+++ b/pkg/blocks/ttps.go
@@ -156,6 +156,11 @@ func (t *TTP) RunSteps(execCtx TTPExecutionContext) error {
 		defer execCtx.ConnPool.CloseAll()
 	}
 
+	// inject TTP-level environment variables into the execution context
+	if len(t.Environment) > 0 {
+		execCtx.GlobalEnv = t.Environment
+	}
+
 	// go to the configuration directory for this TTP
 	changeBack, err := t.chdir()
 	if err != nil {


### PR DESCRIPTION
Summary:
The TTP struct had an `env` field (`Environment map[string]string`) that was
parsed from YAML but never actually used during execution — it was dead code.

This change wires it up so that TTP-level environment variables are injected
into every step's execution environment. The merge order is:

- Local execution: os.Environ() → TTP env → step env (last wins)
- Remote execution: TTP env → step env (no os.Environ inheritance)
- Expect steps: TTP env set first, then step env overrides

This also fixes an existing env ordering bug where step-level env vars were
prepended before os.Environ(), causing inherited vars to silently override
user-specified ones (Go's exec.Cmd.Env uses last-wins semantics).

Example usage:
```yaml
env:
  API_ENDPOINT: "https://internal.corp/api"
  TEAM: "purple"
steps:
  - name: step1
    inline: curl $API_ENDPOINT/health
  - name: step2
    inline: curl $API_ENDPOINT/execute
```

Reviewed By: d0n601

Differential Revision: D100214957


