### PR TITLE
Consolidate parseutils into canonical PreambleFields

### DIFF
--- a/cmd/enumauthors.go
+++ b/cmd/enumauthors.go
@@ -75,7 +75,7 @@ func buildEnumAuthorsCommand(cfg *Config) *cobra.Command {
 					continue
 				}
 
-				ttp, err := parseutils.ParseTTP(content, path)
+				preamble, err := parseutils.ParsePreamble(content, path)
 				if err != nil {
 					if logConfig.Verbose {
 						fmt.Printf("Error parsing TTP ref: %v with error: %v\n", ttpRef, err)
@@ -85,7 +85,7 @@ func buildEnumAuthorsCommand(cfg *Config) *cobra.Command {
 
 				// Aggregate authors
 				hasValidAuthor := false
-				for _, author := range ttp.Authors {
+				for _, author := range preamble.Authors {
 					// Normalize author name (trim spaces)
 					author = strings.TrimSpace(author)
 					if author == "" {

--- a/cmd/enumttps.go
+++ b/cmd/enumttps.go
@@ -24,7 +24,9 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/facebookincubator/ttpforge/pkg/blocks"
 	"github.com/facebookincubator/ttpforge/pkg/parseutils"
+	"github.com/facebookincubator/ttpforge/pkg/platforms"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -76,10 +78,14 @@ func gatherTTPsFromRepo(cfg *Config, repo string) ([]string, error) {
 	return ttpRefs, nil
 }
 
-func matchMitreData(ttp parseutils.TTP, tactic string, technique string, subTech string) bool {
+func matchMitreData(preamble *blocks.PreambleFields, tactic string, technique string, subTech string) bool {
+	if preamble.MitreAttackMapping == nil {
+		return tactic == "" && technique == "" && subTech == ""
+	}
+	mitre := preamble.MitreAttackMapping
 	dataMatching := false
 	if tactic != "" {
-		for _, ttpTactic := range ttp.Mitre.Tactics {
+		for _, ttpTactic := range mitre.Tactics {
 			if strings.Contains(ttpTactic, tactic) {
 				dataMatching = true
 				break
@@ -91,7 +97,7 @@ func matchMitreData(ttp parseutils.TTP, tactic string, technique string, subTech
 		dataMatching = false
 	}
 	if technique != "" {
-		for _, ttpTechnique := range ttp.Mitre.Techniques {
+		for _, ttpTechnique := range mitre.Techniques {
 			if strings.Contains(ttpTechnique, technique) {
 				dataMatching = true
 				break
@@ -103,7 +109,7 @@ func matchMitreData(ttp parseutils.TTP, tactic string, technique string, subTech
 		dataMatching = false
 	}
 	if subTech != "" {
-		for _, ttpSubTech := range ttp.Mitre.Subtechniques {
+		for _, ttpSubTech := range mitre.SubTechniques {
 			if strings.Contains(ttpSubTech, subTech) {
 				dataMatching = true
 				break
@@ -116,11 +122,11 @@ func matchMitreData(ttp parseutils.TTP, tactic string, technique string, subTech
 	return true
 }
 
-func matchAuthor(ttp parseutils.TTP, author string) bool {
+func matchAuthor(preamble *blocks.PreambleFields, author string) bool {
 	if author == "" {
 		return true
 	}
-	for _, ttpAuthor := range ttp.Authors {
+	for _, ttpAuthor := range preamble.Authors {
 		if strings.Contains(strings.ToLower(ttpAuthor), strings.ToLower(author)) {
 			return true
 		}
@@ -160,7 +166,7 @@ func filterTTPs(cfg *Config, filters TTPFilters, ttpRefs []string, tally map[str
 			continue
 		}
 
-		ttp, err := parseutils.ParseTTP(content, path)
+		preamble, err := parseutils.ParsePreamble(content, path)
 		if err != nil {
 			if logConfig.Verbose {
 				fmt.Printf("Error parsing TTP ref: %v with error: %v\n", ttpRef, err)
@@ -168,16 +174,19 @@ func filterTTPs(cfg *Config, filters TTPFilters, ttpRefs []string, tally map[str
 			continue
 		}
 
-		if !matchMitreData(ttp, filters.Tactic, filters.Technique, filters.SubTech) {
+		if !matchMitreData(preamble, filters.Tactic, filters.Technique, filters.SubTech) {
 			continue
 		}
 
-		if !matchAuthor(ttp, filters.Author) {
+		if !matchAuthor(preamble, filters.Author) {
 			continue
 		}
 
 		if filterPlatform {
-			ttpPlatforms := ttp.Requirements.Platforms
+			var ttpPlatforms []platforms.Spec
+			if preamble.Requirements != nil {
+				ttpPlatforms = preamble.Requirements.Platforms
+			}
 			platformMatch := false
 			for _, p := range ttpPlatforms {
 				if platformSet[p.OS] {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -140,16 +140,15 @@ func findTTPByUUID(rc repos.RepoCollection, targetUUID string) (string, error) {
 			continue
 		}
 
-		// Use ParseTTP which only parses the preamble (before steps:)
-		// This avoids YAML parsing issues with Go templates in the steps section
-		ttp, err := parseutils.ParseTTP(content, ttpAbsPath)
+		// Parse only the preamble (before steps:) to avoid YAML issues with Go templates
+		preamble, err := parseutils.ParsePreamble(content, ttpAbsPath)
 		if err != nil {
 			logging.L().Debugf("Failed to parse TTP file %s: %v", ttpAbsPath, err)
 			continue
 		}
 
 		// Compare UUIDs (case-insensitive)
-		if strings.EqualFold(ttp.UUID, targetUUID) {
+		if strings.EqualFold(preamble.UUID, targetUUID) {
 			// Convert absolute path back to reference format
 			ref, err := rc.ConvertAbsPathToAbsRef(repo, ttpAbsPath)
 			if err != nil {

--- a/pkg/blocks/context.go
+++ b/pkg/blocks/context.go
@@ -60,6 +60,7 @@ type TTPExecutionVars struct {
 type TTPExecutionContext struct {
 	Cfg               TTPExecutionConfig
 	Vars              *TTPExecutionVars
+	GlobalEnv         map[string]string
 	StepResults       *StepResultsRecord
 	Backend           backends.ExecutionBackend
 	ConnPool          *backends.ConnectionPool

--- a/pkg/blocks/executor.go
+++ b/pkg/blocks/executor.go
@@ -130,8 +130,9 @@ func (e *ScriptExecutor) Execute(ctx context.Context, execCtx TTPExecutionContex
 
 	// Remote backend path: delegate to backend.RunCommand
 	if execCtx.Backend != nil {
-		// For remote execution, only pass explicitly declared env vars
-		expandedEnvAsList, err := execCtx.ExpandVariables(FetchEnv(e.Environment))
+		// For remote execution, pass TTP-level env + step env (no os.Environ)
+		envAsList := append(FetchEnv(execCtx.GlobalEnv), FetchEnv(e.Environment)...)
+		expandedEnvAsList, err := execCtx.ExpandVariables(envAsList)
 		if err != nil {
 			return nil, err
 		}
@@ -153,8 +154,9 @@ func (e *ScriptExecutor) Execute(ctx context.Context, execCtx TTPExecutionContex
 		logging.L().Debugw("executor found in path", "executor", e.Name)
 	}
 
-	// expand variables in environment (include inherited env for local execution)
-	envAsList := append(FetchEnv(e.Environment), os.Environ()...)
+	// Build environment: inherited → TTP-level → step-level (last wins)
+	envAsList := append(os.Environ(), FetchEnv(execCtx.GlobalEnv)...)
+	envAsList = append(envAsList, FetchEnv(e.Environment)...)
 	expandedEnvAsList, err := execCtx.ExpandVariables(envAsList)
 	if err != nil {
 		return nil, err
@@ -178,7 +180,9 @@ func (e *FileExecutor) Execute(ctx context.Context, execCtx TTPExecutionContext)
 
 	// Remote backend path: delegate to backend.RunCommand
 	if execCtx.Backend != nil {
-		expandedEnvAsList, err := execCtx.ExpandVariables(FetchEnv(e.Environment))
+		// For remote execution, pass TTP-level env + step env (no os.Environ)
+		envAsList := append(FetchEnv(execCtx.GlobalEnv), FetchEnv(e.Environment)...)
+		expandedEnvAsList, err := execCtx.ExpandVariables(envAsList)
 		if err != nil {
 			return nil, err
 		}
@@ -210,8 +214,9 @@ func (e *FileExecutor) Execute(ctx context.Context, execCtx TTPExecutionContext)
 		logging.L().Debugw("executor found in path", "executor", e.Name)
 	}
 
-	// expand variables in environment (include inherited env for local execution)
-	envAsList := append(FetchEnv(e.Environment), os.Environ()...)
+	// Build environment: inherited → TTP-level → step-level (last wins)
+	envAsList := append(os.Environ(), FetchEnv(execCtx.GlobalEnv)...)
+	envAsList = append(envAsList, FetchEnv(e.Environment)...)
 	expandedEnvAsList, err := execCtx.ExpandVariables(envAsList)
 	if err != nil {
 		return nil, err

--- a/pkg/blocks/expectstep.go
+++ b/pkg/blocks/expectstep.go
@@ -218,11 +218,15 @@ func (s *ExpectStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
 		logging.L().Warnf("failed to set terminal width: %v", err)
 	}
 
-	if s.Environment != nil {
-		for k, v := range s.Environment {
-			if err := os.Setenv(k, v); err != nil {
-				return nil, fmt.Errorf("failed to set environment variable: %w", err)
-			}
+	// Set TTP-level env vars first, then step-level (step overrides TTP)
+	for k, v := range execCtx.GlobalEnv {
+		if err := os.Setenv(k, v); err != nil {
+			return nil, fmt.Errorf("failed to set environment variable: %w", err)
+		}
+	}
+	for k, v := range s.Environment {
+		if err := os.Setenv(k, v); err != nil {
+			return nil, fmt.Errorf("failed to set environment variable: %w", err)
 		}
 	}
 

--- a/pkg/blocks/preamble.go
+++ b/pkg/blocks/preamble.go
@@ -40,6 +40,7 @@ type PreambleFields struct {
 	APIVersion         string              `yaml:"api_version,omitempty"`
 	UUID               string              `yaml:"uuid,omitempty"`
 	Name               string              `yaml:"name,omitempty"`
+	Authors            []string            `yaml:"authors,omitempty"`
 	Description        string              `yaml:"description"`
 	MitreAttackMapping *MitreAttack        `yaml:"mitre,omitempty"`
 	Requirements       *RequirementsConfig `yaml:"requirements,omitempty"`

--- a/pkg/blocks/ttps.go
+++ b/pkg/blocks/ttps.go
@@ -156,6 +156,11 @@ func (t *TTP) RunSteps(execCtx TTPExecutionContext) error {
 		defer execCtx.ConnPool.CloseAll()
 	}
 
+	// inject TTP-level environment variables into the execution context
+	if len(t.Environment) > 0 {
+		execCtx.GlobalEnv = t.Environment
+	}
+
 	// go to the configuration directory for this TTP
 	changeBack, err := t.chdir()
 	if err != nil {

--- a/pkg/parseutils/parsefile.go
+++ b/pkg/parseutils/parsefile.go
@@ -23,58 +23,21 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/facebookincubator/ttpforge/pkg/blocks"
 	"gopkg.in/yaml.v3"
 )
 
-// Arg is a struct that represents the information of an argument in a TTP in a YAML file.
-type Arg struct {
-	Name        string `yaml:"name"`
-	Description string `yaml:"description,omitempty"`
-	Type        string `yaml:"type,omitempty"`
-	Choices     []any  `yaml:"choices,omitempty"`
-	Default     any    `yaml:"default,omitempty"`
-}
-
-// Mitre is a struct that represents a MITRE tactic, technique, or subtechnique in a YAML file.
-type Mitre struct {
-	Tactics       []string `yaml:"tactics,omitempty"`
-	Techniques    []string `yaml:"techniques,omitempty"`
-	Subtechniques []string `yaml:"subtechniques,omitempty"`
-}
-
-// Platform is a struct that represents a platform in a YAML file like Windows, Linux, etc.
-type Platform struct {
-	OS string `yaml:"os"`
-}
-
-// Requirements is a struct that represents the requirements of a TTP in a YAML file like Platform (OS), superuser, etc.
-type Requirements struct {
-	Platforms []Platform `yaml:"platforms,omitempty"`
-	Superuser bool       `yaml:"superuser,omitempty"`
-}
-
-// TTP is a struct that represents a TTP in a YAML file.
-type TTP struct {
-	APIVersion   string       `yaml:"api_version"`
-	UUID         string       `yaml:"uuid"`
-	Name         string       `yaml:"name"`
-	Authors      []string     `yaml:"authors,omitempty"`
-	Description  string       `yaml:"description"`
-	Requirements Requirements `yaml:"requirements,omitempty"`
-	Mitre        Mitre        `yaml:"mitre,omitempty"`
-	Args         []Arg        `yaml:"args,omitempty"`
-}
-
-// ParseTTP parses a YAML file and returns a map of the contents.
-func ParseTTP(data []byte, filename string) (TTP, error) {
-	// Find steps: in data
+// ParsePreamble parses the preamble of a TTP YAML file into the canonical
+// blocks.PreambleFields struct. It truncates at the steps: boundary to avoid
+// parsing issues with Go templates in the steps section.
+func ParsePreamble(data []byte, filename string) (*blocks.PreambleFields, error) {
 	stepsIndex := bytes.Index(data, []byte("\nsteps:"))
 	if stepsIndex != -1 {
 		data = data[:stepsIndex+1]
 	}
-	var ttp TTP
-	if err := yaml.Unmarshal(data, &ttp); err != nil {
-		return TTP{}, fmt.Errorf("Failed to unmarshal file %s: %w", filename, err)
+	var preamble blocks.PreambleFields
+	if err := yaml.Unmarshal(data, &preamble); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal preamble from %s: %w", filename, err)
 	}
-	return ttp, nil
+	return &preamble, nil
 }

--- a/pkg/parseutils/parsefile_test.go
+++ b/pkg/parseutils/parsefile_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseTTP(t *testing.T) {
+func TestParsePreamble(t *testing.T) {
 	tests := []struct {
 		name        string
 		ttpStr      string
@@ -68,7 +68,7 @@ args:
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := ParseTTP([]byte(tc.ttpStr), tc.name+".yaml")
+			_, err := ParsePreamble([]byte(tc.ttpStr), tc.name+".yaml")
 			if tc.expectError {
 				require.Error(t, err)
 			} else {

--- a/pkg/validation/integration.go
+++ b/pkg/validation/integration.go
@@ -124,30 +124,29 @@ func renderTemplatedTTPForValidation(ttpStr string, rp blocks.RenderParameters) 
 func extractDummyArgsFromTTP(ttpStr string) map[string]any {
 	dummyArgs := make(map[string]any)
 
-	// Use parseutils to parse the TTP header (which includes args but excludes steps)
-	// This handles template control structures in steps gracefully
-	ttp, err := parseutils.ParseTTP([]byte(ttpStr), "validation")
+	// Parse only the preamble (before steps:) to avoid template issues in steps
+	preamble, err := parseutils.ParsePreamble([]byte(ttpStr), "validation")
 	if err != nil {
 		logging.L().Debugf("Failed to parse TTP for arg extraction: %v", err)
 		return dummyArgs
 	}
 
 	// Create dummy values from parsed args
-	for _, arg := range ttp.Args {
+	for _, spec := range preamble.ArgSpecs {
 		// Check if there's a default value (highest priority)
-		if arg.Default != nil {
-			dummyArgs[arg.Name] = arg.Default
+		if spec.Default != nil {
+			dummyArgs[spec.Name] = *spec.Default
 			continue
 		}
 
 		// Check if there are choices (use first choice)
-		if len(arg.Choices) > 0 {
-			dummyArgs[arg.Name] = arg.Choices[0]
+		if len(spec.Choices) > 0 {
+			dummyArgs[spec.Name] = spec.Choices[0]
 			continue
 		}
 
 		// Generate dummy value based on type (lowest priority)
-		dummyArgs[arg.Name] = generateDummyValueForType(arg.Type)
+		dummyArgs[spec.Name] = generateDummyValueForType(spec.Type)
 	}
 
 	return dummyArgs


### PR DESCRIPTION
Summary:
Add the missing `Authors []string` field to `blocks.PreambleFields` and
create `parseutils.ParsePreambleOnly()` which returns the canonical struct.
Then migrate all 4 callers of the old `parseutils.ParseTTP()` and delete
the parallel type definitions (`TTP`, `Arg`, `Mitre`, `Platform`,
`Requirements`).

This eliminates the maintenance burden of keeping two TTP preamble struct
definitions in sync. There is now a single canonical preamble type
(`blocks.PreambleFields`) used throughout the codebase.

Callers migrated:
- cmd/run.go (UUID lookup)
- cmd/enumauthors.go (author aggregation)
- cmd/enumttps.go (MITRE/platform/author filtering)
- pkg/validation/integration.go (dummy arg extraction)

Key type mappings:
- parseutils.Mitre → *blocks.MitreAttack (pointer, nil-check added)
- parseutils.Requirements → *blocks.RequirementsConfig (pointer, nil-check added)
- parseutils.Arg.Default (any) → args.Spec.Default (*string, dereference added)
- parseutils.Arg.Choices ([]any) → args.Spec.Choices ([]string)

Reviewed By: d0n601

Differential Revision: D100220109


