### PR TITLE
Fix flaky TestKillProcessExecute by using a truly non-existent PID

### DIFF
--- a/pkg/blocks/killprocess_test.go
+++ b/pkg/blocks/killprocess_test.go
@@ -44,7 +44,7 @@ func TestKillProcessExecute(t *testing.T) {
 			name:        "Kill non-existent process with id - throw error",
 			description: "Trying to kill a process with id that doesn't exist",
 			step: &KillProcessStep{
-				KillProcess:               KillProcessConfig{ID: "123"},
+				KillProcess:               KillProcessConfig{ID: "123456789"},
 				ErrorOnFindProcessFailure: true,
 			},
 			createProcess:      false,


### PR DESCRIPTION
Summary:
The `Kill_non-existent_process_with_id_-_throw_error` subtest in `pkg/blocks/killprocess_test.go` was failing because it used PID `123` to represent a "non-existent" process. On some hosts, PID 123 is a live kernel thread, so `processutils.VerifyPIDExists` succeeded and the test then attempted to kill it. The kill failed with "operation not permitted", but `ErrorOnKillFailure` defaults to `false`, so the error was logged and swallowed and `Execute` returned `nil`, causing the `require.Error` assertion to fail.

Switching the test PID to `123456789` makes `VerifyPIDExists` actually fail (no such process).

Before this diff, the test fails:

```
$ buck2 test fbcode//security/redteam/purple_team/ttpforge/pkg/blocks:blocks
...
✗ Fail: fbcode//security/redteam/purple_team/ttpforge/pkg/blocks:blocks_test - TestKillProcessExecute (2.1s)
=== RUN   TestKillProcessExecute
=== RUN   TestKillProcessExecute/Kill_non-existent_process_with_id_-_throw_error
INFOUsing Process ID: 123
INFOKilling the following processes: [123]
INFOGot process handle with PID: 123
ERRORFailed to kill process with ID: 123; operation not permitted
    killprocess_test.go:215:
        Error Trace:fbcode/security/redteam/purple_team/ttpforge/pkg/blocks/killprocess_test.go:215
        Error:      An error is expected but got nil.
        Test:       TestKillProcessExecute/Kill_non-existent_process_with_id_-_throw_error
--- FAIL: TestKillProcessExecute (1.79s)
    --- FAIL: TestKillProcessExecute/Kill_non-existent_process_with_id_-_throw_error (0.23s)
1 TESTS FAILED
  ✗ fbcode//security/redteam/purple_team/ttpforge/pkg/blocks:blocks_test - TestKillProcessExecute
```

Now, the test passes

Differential Revision: D102369915


