### PR TITLE
Allow per-step execution timeout override (basic and file steps) (#617)

### DIFF
--- a/pkg/blocks/actions.go
+++ b/pkg/blocks/actions.go
@@ -19,6 +19,19 @@ THE SOFTWARE.
 
 package blocks
 
+import (
+	"fmt"
+	"time"
+)
+
+// DefaultExecutionTimeout is the default timeout for step execution.
+const DefaultExecutionTimeout = 100 * time.Minute
+
+// maxExecutionTimeout is the hard upper bound on a step's execution timeout,
+// even when a step explicitly opts in via long_running. It guards against
+// runaway typos like step_timeout: 700h.
+const maxExecutionTimeout = 24 * time.Hour
+
 // Action is an interface that is implemented
 // by all action types used in steps/cleanups
 // (such as create_file, inline, etc)
@@ -39,6 +52,65 @@ type Action interface {
 type actionDefaults struct {
 	Description string `yaml:"description,omitempty"`
 	OutputVar   string `yaml:"outputvar,omitempty"`
+}
+
+// timedActionDefaults adds opt-in per-step deadline fields. Embed this only
+// in step types whose execution honors a context deadline (basic, file).
+// Step types that do not embed this will not surface step_timeout /
+// long_running in their YAML schema.
+type timedActionDefaults struct {
+	StepTimeout string `yaml:"step_timeout,omitempty"`
+	LongRunning bool   `yaml:"long_running,omitempty"`
+
+	// resolved memoizes the parsed StepTimeout so Validate and Execute
+	// don't repeat the parse + range checks. A successful resolve always
+	// yields a positive duration, so zero unambiguously means "not yet
+	// resolved". Errors are not cached so repeated calls report consistently.
+	resolved time.Duration `yaml:"-"`
+}
+
+// resolveTimeout returns the effective execution timeout for a step.
+//
+// Behavior:
+//   - StepTimeout empty → returns DefaultExecutionTimeout (100m).
+//   - StepTimeout set → parsed via time.ParseDuration.
+//   - Parsed duration must be > 0.
+//   - Parsed duration must not exceed maxExecutionTimeout.
+//   - Parsed duration > DefaultExecutionTimeout requires LongRunning: true,
+//     so that long-timeout steps are explicitly opted in and discoverable in YAML.
+//
+// Checks are ordered so the first error a user sees is actionable: if the
+// value is over the absolute cap, telling them to set long_running: true
+// would be misleading because the value would still be rejected.
+func (t *timedActionDefaults) resolveTimeout() (time.Duration, error) {
+	if t.resolved != 0 {
+		return t.resolved, nil
+	}
+	if t.StepTimeout == "" {
+		t.resolved = DefaultExecutionTimeout
+		return t.resolved, nil
+	}
+	d, err := time.ParseDuration(t.StepTimeout)
+	if err != nil {
+		return 0, fmt.Errorf("invalid step_timeout %q: %w", t.StepTimeout, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("step_timeout must be > 0, got %q", t.StepTimeout)
+	}
+	if d > maxExecutionTimeout {
+		return 0, fmt.Errorf(
+			"step_timeout %q exceeds the maximum allowed of %s",
+			t.StepTimeout, maxExecutionTimeout,
+		)
+	}
+	if d > DefaultExecutionTimeout && !t.LongRunning {
+		return 0, fmt.Errorf(
+			"step_timeout %q exceeds the default of %s; set long_running: true to opt in",
+			t.StepTimeout, DefaultExecutionTimeout,
+		)
+	}
+	t.resolved = d
+	return t.resolved, nil
 }
 
 // IsNil provides a default implementation

--- a/pkg/blocks/actions_test.go
+++ b/pkg/blocks/actions_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright © 2024-present, Meta Platforms, Inc. and affiliates
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+package blocks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveTimeout(t *testing.T) {
+	testCases := []struct {
+		name          string
+		stepTimeout   string
+		longRunning   bool
+		want          time.Duration
+		wantErr       bool
+		wantErrSubstr string
+	}{
+		{
+			name: "default when unset",
+			want: DefaultExecutionTimeout,
+		},
+		{
+			name:        "shorter than default needs no opt-in",
+			stepTimeout: "30m",
+			want:        30 * time.Minute,
+		},
+		{
+			name:        "equal to default needs no opt-in",
+			stepTimeout: "100m",
+			want:        DefaultExecutionTimeout,
+		},
+		{
+			name:        "longer than default with long_running",
+			stepTimeout: "7h",
+			longRunning: true,
+			want:        7 * time.Hour,
+		},
+		{
+			name:          "longer than default without long_running rejected",
+			stepTimeout:   "7h",
+			wantErr:       true,
+			wantErrSubstr: "long_running",
+		},
+		{
+			name:          "exceeds max even with long_running",
+			stepTimeout:   "25h",
+			longRunning:   true,
+			wantErr:       true,
+			wantErrSubstr: "maximum allowed",
+		},
+		{
+			// Regression: when both the long_running gate and the max-cap
+			// would reject the value, the user should see the max-cap error
+			// first -- otherwise they'd be told to opt in via long_running
+			// and then hit a second rejection on the next attempt.
+			name:          "exceeds max without long_running reports max not opt-in",
+			stepTimeout:   "25h",
+			wantErr:       true,
+			wantErrSubstr: "maximum allowed",
+		},
+		{
+			name:          "zero rejected",
+			stepTimeout:   "0s",
+			wantErr:       true,
+			wantErrSubstr: "must be > 0",
+		},
+		{
+			name:          "negative rejected",
+			stepTimeout:   "-5m",
+			wantErr:       true,
+			wantErrSubstr: "must be > 0",
+		},
+		{
+			name:          "unparsable rejected",
+			stepTimeout:   "not-a-duration",
+			wantErr:       true,
+			wantErrSubstr: "invalid step_timeout",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			td := timedActionDefaults{
+				StepTimeout: tc.stepTimeout,
+				LongRunning: tc.longRunning,
+			}
+			got, err := td.resolveTimeout()
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrSubstr != "" {
+					assert.Contains(t, err.Error(), tc.wantErrSubstr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/blocks/basicstep.go
+++ b/pkg/blocks/basicstep.go
@@ -23,22 +23,19 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/facebookincubator/ttpforge/pkg/logging"
 	"github.com/facebookincubator/ttpforge/pkg/outputs"
 )
 
-// DefaultExecutionTimeout is the default timeout for step execution.
-const DefaultExecutionTimeout = 100 * time.Minute
-
 // BasicStep is a type that represents a basic execution step.
 type BasicStep struct {
-	actionDefaults `yaml:",inline"`
-	ExecutorName   string                  `yaml:"executor,omitempty"`
-	Inline         string                  `yaml:"inline,flow"`
-	Environment    map[string]string       `yaml:"env,omitempty"`
-	Outputs        map[string]outputs.Spec `yaml:"outputs,omitempty"`
+	actionDefaults      `yaml:",inline"`
+	timedActionDefaults `yaml:",inline"`
+	ExecutorName        string                  `yaml:"executor,omitempty"`
+	Inline              string                  `yaml:"inline,flow"`
+	Environment         map[string]string       `yaml:"env,omitempty"`
+	Outputs             map[string]outputs.Spec `yaml:"outputs,omitempty"`
 }
 
 // NewBasicStep creates a new BasicStep instance with an initialized Act struct.
@@ -69,6 +66,10 @@ func (b *BasicStep) Validate(execCtx TTPExecutionContext) error {
 		b.ExecutorName = ExecutorBash
 	}
 
+	if _, err := b.resolveTimeout(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -84,7 +85,11 @@ func (b *BasicStep) Template(execCtx TTPExecutionContext) error {
 
 // Execute runs the step and returns an error if one occurs.
 func (b *BasicStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultExecutionTimeout)
+	timeout, err := b.resolveTimeout()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	if b.Inline == "" {

--- a/pkg/blocks/basicstep_test.go
+++ b/pkg/blocks/basicstep_test.go
@@ -21,6 +21,7 @@ package blocks
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -161,6 +162,43 @@ outputvar: foo`
 	_, err = s.Execute(execCtx)
 	require.NoError(t, err)
 	assert.Equal(t, "line1\nline2\n\nline4\n", execCtx.Vars.StepVars["foo"], "outputvar should be set")
+}
+
+func TestBasicStepValidateRejectsLongTimeoutWithoutOptIn(t *testing.T) {
+	content := `name: test_basic_step
+inline: echo hi
+step_timeout: 7h`
+	var s BasicStep
+	execCtx := NewTTPExecutionContext()
+	err := yaml.Unmarshal([]byte(content), &s)
+	require.NoError(t, err)
+	err = s.Validate(execCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "long_running")
+}
+
+func TestBasicStepExecuteHonorsShortStepTimeout(t *testing.T) {
+	// Use a bash-internal busy loop rather than `sleep N`. `sleep` forks a
+	// child of bash that inherits the stdout/stderr pipes; after bash gets
+	// SIGKILL'd at the deadline, cmd.Wait() blocks until the orphaned sleep
+	// also exits (it would naturally end at 5s). A pure-bash loop has no
+	// descendants holding the pipes, so kill takes effect immediately.
+	content := `name: test_basic_step
+inline: while true; do :; done
+step_timeout: 500ms`
+	var s BasicStep
+	execCtx := NewTTPExecutionContext()
+	err := yaml.Unmarshal([]byte(content), &s)
+	require.NoError(t, err)
+	err = s.Validate(execCtx)
+	require.NoError(t, err)
+
+	start := time.Now()
+	_, err = s.Execute(execCtx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "Execute should fail when inline outlasts step_timeout")
+	assert.Less(t, elapsed, 3*time.Second, "subprocess was not killed near the step_timeout deadline")
 }
 
 func TestBasicStepExecuteOutputsToAndOverwritesOutputVar(t *testing.T) {

--- a/pkg/blocks/executor.go
+++ b/pkg/blocks/executor.go
@@ -167,7 +167,7 @@ func (e *ScriptExecutor) Execute(ctx context.Context, execCtx TTPExecutionContex
 	cmd.Dir = execCtx.Vars.WorkDir
 	cmd.Stdin = strings.NewReader(body)
 
-	return streamAndCapture(*cmd, execCtx.Cfg.Stdout, execCtx.Cfg.Stderr)
+	return streamAndCapture(cmd, execCtx.Cfg.Stdout, execCtx.Cfg.Stderr)
 }
 
 // Execute runs the binary with arguments
@@ -232,7 +232,7 @@ func (e *FileExecutor) Execute(ctx context.Context, execCtx TTPExecutionContext)
 
 	cmd.Env = expandedEnvAsList
 	cmd.Dir = execCtx.Vars.WorkDir
-	return streamAndCapture(*cmd, execCtx.Cfg.Stdout, execCtx.Cfg.Stderr)
+	return streamAndCapture(cmd, execCtx.Cfg.Stdout, execCtx.Cfg.Stderr)
 }
 
 // InferExecutor infers the executor based on the file extension and

--- a/pkg/blocks/filestep.go
+++ b/pkg/blocks/filestep.go
@@ -30,12 +30,13 @@ import (
 // FileStep represents a step in a process that consists of a main action,
 // a cleanup action, and additional metadata.
 type FileStep struct {
-	actionDefaults `yaml:",inline"`
-	FilePath       string                  `yaml:"file,omitempty"`
-	Executor       string                  `yaml:"executor,omitempty"`
-	Environment    map[string]string       `yaml:"env,omitempty"`
-	Outputs        map[string]outputs.Spec `yaml:"outputs,omitempty"`
-	Args           []string                `yaml:"args,omitempty,flow"`
+	actionDefaults      `yaml:",inline"`
+	timedActionDefaults `yaml:",inline"`
+	FilePath            string                  `yaml:"file,omitempty"`
+	Executor            string                  `yaml:"executor,omitempty"`
+	Environment         map[string]string       `yaml:"env,omitempty"`
+	Outputs             map[string]outputs.Spec `yaml:"outputs,omitempty"`
+	Args                []string                `yaml:"args,omitempty,flow"`
 }
 
 // NewFileStep creates a new FileStep instance and returns a pointer to it.
@@ -73,6 +74,10 @@ func (f *FileStep) Validate(execCtx TTPExecutionContext) error {
 		f.Executor = InferExecutor(f.FilePath)
 	}
 
+	if _, err := f.resolveTimeout(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -102,7 +107,11 @@ func (f *FileStep) Template(execCtx TTPExecutionContext) error {
 
 // Execute runs the step and returns an error if one occurs.
 func (f *FileStep) Execute(execCtx TTPExecutionContext) (*ActResult, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultExecutionTimeout)
+	timeout, err := f.resolveTimeout()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	// Resolve file path at execution time

--- a/pkg/blocks/filestep_test.go
+++ b/pkg/blocks/filestep_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"gopkg.in/yaml.v3"
 )
@@ -95,4 +96,17 @@ func getDefaultExecutor() string {
 		return ExecutorCmd
 	}
 	return ExecutorSh
+}
+
+func TestFileStepValidateRejectsLongTimeoutWithoutOptIn(t *testing.T) {
+	content := `name: test_file_step
+file: script.sh
+step_timeout: 7h`
+	var f FileStep
+	execCtx := NewTTPExecutionContext()
+	err := yaml.Unmarshal([]byte(content), &f)
+	require.NoError(t, err)
+	err = f.Validate(execCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "long_running")
 }

--- a/pkg/blocks/iocapture.go
+++ b/pkg/blocks/iocapture.go
@@ -97,7 +97,13 @@ func defaultStreamWriter(prefix string) *bufferedWriter {
 	}
 }
 
-func streamAndCapture(cmd exec.Cmd, stdout, stderr io.Writer) (*ActResult, error) {
+// streamAndCapture takes cmd by pointer because os/exec.Cmd contains internal
+// state (notably the watchdog goroutine started by CommandContext, which holds
+// a reference to cmd.Process) that is unsafe to copy. Passing by value used to
+// be benign only because the previous 100m default timeout never expired in
+// practice; with user-controlled step_timeout values it will, and the watchdog
+// would dereference a nil Process on the original copy.
+func streamAndCapture(cmd *exec.Cmd, stdout, stderr io.Writer) (*ActResult, error) {
 	if stdout == nil {
 		stdout = &bufferedWriter{
 			writer: &zapWriter{


### PR DESCRIPTION
Summary:

TTPForge currently caps every basic/file step at a hardcoded 100-minute execution timeout. This blocks any TTP whose single step legitimately runs longer than 100 minutes
   - This blocks creating a TTP which simulates DNS beaconing behavior over a 5 hour period.
   - TTPs with very long running behavior should be run in the background, so they aren't hogging a host for hours.

This adds two new fields to basic/file steps:
  - step_timeout: Go duration string (e.g. "7h", "30m"). Optional.
  - long_running: bool. Required true to set step_timeout > 100m.

Including the `long_running` bool makes it more obvious that the default timeout has been changed. It also prevents YAML authors from changing the default timeout to something very long without acknowledging the long duration.

Hard cap of MaxExecutionTimeout = 24h applies even with long_running: true. I don't think there are any TTPs that would require a timeout longer than that. This protects against typos.

Differential Revision: D102381432


