### PR TITLE
Fix Windows fbpkg build: adapt pty.Winsize cast to uint/uint16 across build envs

### DIFF
--- a/pkg/blocks/winsize_windows.go
+++ b/pkg/blocks/winsize_windows.go
@@ -23,6 +23,18 @@ package blocks
 
 import "github.com/creack/pty"
 
+// pty.Winsize's Rows/Cols are uint16 in the fbcode-vendored creack/pty but uint
+// in the upstream module's Windows variant, so a fixed cast fails one build or
+// the other. setDim infers the field's own integer type and converts to it,
+// letting this compile under both the internal buck opt-win build and the OSS
+// GOOS=windows cross-compile.
 func newWinsize(rows, cols int) pty.Winsize {
-	return pty.Winsize{Rows: uint(rows), Cols: uint(cols)}
+	var ws pty.Winsize
+	setDim(&ws.Rows, rows)
+	setDim(&ws.Cols, cols)
+	return ws
+}
+
+func setDim[T ~uint | ~uint16](dst *T, v int) {
+	*dst = T(v)
 }


### PR DESCRIPTION
Summary:
Context: The `blackbird/ttpforge_binaries` Conveyor pipeline builds `blackbird.one_platform.ttpforge_{linux,linux_arm64,macos,windows_x86_64}` in a single release and preserves them via one shared `preserve_v1` node. Since 2026-06-02 every release (R3470–R3489+) FAILED on the `ttpforge_windows_x86_64` build node, which blocks `preserve_v1`, so no package — including the healthy `ttpforge_linux` — got a fresh DEFAULT. The 48-day-old default triggered a stale-code UBN (T279859531, the 3rd recurrence).

Motivation: The windows build node fails to compile `winsize_windows.go`. The root cause is that `pty.Winsize.Rows/Cols` have DIFFERENT integer types depending on which `github.com/creack/pty` is on the module path:
- fbcode-vendored creack/pty (internal buck `opt-win`): the fields are `uint16`.
- upstream creack/pty (OSS GitHub Actions `GOOS=windows go build`): the fields are `uint`.

`newWinsize` was split into build-tagged helpers in D106692973, but that split is unix-vs-windows — it cannot distinguish internal-vs-OSS within Windows. Any single hardcoded cast satisfies exactly one of the two builds and breaks the other: `uint16` fixes the internal buck build but breaks the OSS cross-compile check that D106692973 itself added, and `uint` does the reverse. (That is why the first version of this diff, which used `uint16`, passed internal buck but failed the `facebookincubator/TTPForge` OSS test signal with "cannot use uint16(rows) as uint value".)

This diff: replace the fixed cast in `winsize_windows.go` with a generic `setDim[T ~uint | ~uint16]` helper that infers the struct field's own integer type and converts to it. This compiles under both build environments, with no change to the vendored third-party and no change to the Unix path.

Reviewed By: sriharic-meta

Differential Revision: D113022608


